### PR TITLE
Remove the format stage from the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,5 @@
 image: golang:latest
 
-format:
-  stage: test
-  script:
-    - make format-tools
-    - make format
-
 lint:
   stage: test
   variables:


### PR DESCRIPTION
Format is checked in the lint stage. make format does not check
the format, it formats the code when it is not formatted correctly
yet. It makes no sense to run this in the CI.