### PR TITLE
Removed confusing log that can appear when writing secret for the first time

### DIFF
--- a/pkg/secrethub/http.go
+++ b/pkg/secrethub/http.go
@@ -638,7 +638,6 @@ func (c *httpClient) do(rawURL string, method string, expectedStatus int, in int
 			"Client is out of date\n" +
 				"Go to `https://secrethub.io/docs/getting-started/install` to see how to update your client.")
 	} else if resp.StatusCode != expectedStatus {
-		log.Debugf("unexpected status code: %d (actual) != %d (expected)", resp.StatusCode, expectedStatus)
 		return parseError(resp)
 	}
 


### PR DESCRIPTION
When writing a secret for the first time, the following statement can appear in the logs: `unexpected status code: 404 (actual) != 200 (expected)`, even though the secret was successfully written, due to first checking if the secret exists. Not a huge deal, but could confuse users of the client.