### PR TITLE
Remove readme section about test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ If you'd like to contribute, please checkout [the contributing guidelines](./CON
 
 ## Test
 
-Before running the tests, make sure to grab all of the package's dependencies:
-
-    go get -t
-
 Run all tests:
 
     make test


### PR DESCRIPTION
Test dependencies are already fetched when using go get, because
we're using gomodules. Also, we don't have test-only dependencies.