### PR TITLE
Add marshal functions to api types

### DIFF
--- a/pkg/api/account.go
+++ b/pkg/api/account.go
@@ -29,7 +29,7 @@ type Account struct {
 // AccountName represents the name of either a user or a service.
 type AccountName string
 
-// NewAccountName validates an accounts name and returns it as a typed AccountName when valid.
+// NewAccountName validates an account's name and returns it as a typed AccountName when valid.
 func NewAccountName(name string) (AccountName, error) {
 	err := ValidateAccountName(name)
 	if err != nil {
@@ -63,12 +63,12 @@ func (n *AccountName) Set(value string) error {
 	return nil
 }
 
-// String returns the accounts name as a string to be used for printing.
+// String returns the account's name as a string to be used for printing.
 func (n AccountName) String() string {
 	return string(n)
 }
 
-// Marshal returns the accounts name as a string to be used in communication
+// Marshal returns the account's name as a string to be used in communication
 // with the client and in transportation to the server.
 func (n AccountName) Marshal() string {
 	return string(n)

--- a/pkg/api/paths.go
+++ b/pkg/api/paths.go
@@ -443,12 +443,12 @@ func (rp *RepoPath) Set(value string) error {
 	return nil
 }
 
-// String returns the repositories path as a string to be used for printing.
+// String returns the repository's path as a string to be used for printing.
 func (rp RepoPath) String() string {
 	return string(rp)
 }
 
-// Marshal returns the repositories path as a string to be used in communication
+// Marshal returns the repository's path as a string to be used in communication
 // with the client and in transportation to the server.
 func (rp RepoPath) Marshal() string {
 	return string(rp)
@@ -542,12 +542,12 @@ func (n *OrgName) Set(value string) error {
 	return nil
 }
 
-// String returns the organisations name as a string to be used for printing.
+// String returns the organisation's name as a string to be used for printing.
 func (n OrgName) String() string {
 	return string(n)
 }
 
-// Marshal returns the organisations name as a string to be used in communication
+// Marshal returns the organisation's name as a string to be used in communication
 // with the client and in transportation to the server.
 func (n OrgName) Marshal() string {
 	return string(n)


### PR DESCRIPTION
The api types for which primitive arguments are used in communication
with the client, I've added Marshal functions to retrieve the
representation in this primitive type. For api types for which
this type is String, this makes sure we destinguish the function
used for printing: String() and the function used to get the
representation for communication: Marshal.