### PR TITLE
Add more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,4 +20,5 @@ linters:
   - unparam
   - nakedret
   - gofmt
+  - misspell
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,4 +19,5 @@ linters:
   - depguard
   - unparam
   - nakedret
+  - gofmt
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,4 +22,5 @@ linters:
   - gofmt
   - misspell
   - prealloc
+  - goconst
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,4 +21,5 @@ linters:
   - nakedret
   - gofmt
   - misspell
+  - prealloc
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,4 +5,18 @@ linters:
   - golint
   - staticcheck
   - vet
+  - unused
+  - gosimple
+  - stylecheck
+  - structcheck
+  - varcheck
+  - interfacer
+  - unconvert
+  - ineffassign
+  - deadcode
+  - gocyclo
+  - typecheck
+  - depguard
+  - unparam
+  - nakedret
   disable-all: true

--- a/internals/crypto/ciphertext.go
+++ b/internals/crypto/ciphertext.go
@@ -104,9 +104,11 @@ func newEncodedCiphertextMetadata(metadataList map[string]string) encodedCiphert
 	metadata := ""
 
 	// Sort all the keys of the metadataList so that metadata is always in alphabetical order.
-	var keys []string
+	keys := make([]string, len(metadataList))
+	i := 0
 	for k := range metadataList {
-		keys = append(keys, k)
+		keys[i] = k
+		i++
 	}
 	sort.Strings(keys)
 

--- a/internals/crypto/scrypt.go
+++ b/internals/crypto/scrypt.go
@@ -33,7 +33,7 @@ const (
 	// Read more about the parameters, how they work and how to determine their values
 	// in this blog post: https://blog.filippo.io/the-scrypt-parameters/
 	//
-	// Also, this the value recommented in the official GoDocs.
+	// Also, this the value recommended in the official GoDocs.
 	DefaultScryptN = 1 << 15
 
 	// DefaultScryptR determines the sequential read size of the scrypt
@@ -44,7 +44,7 @@ const (
 	// different memory characteristics. Use the N parameter instead to
 	// increase or decrease work.
 	//
-	// The value has been set to 8, which is the value recommented in
+	// The value has been set to 8, which is the value recommended in
 	// the official GoDocs.
 	DefaultScryptR = 8
 
@@ -54,7 +54,7 @@ const (
 	// be used to decrease the wall-clock-time of the key derivation
 	// function. Use the N parameter for that.
 	//
-	// The value has been set to 1, which is the value recommented in
+	// The value has been set to 1, which is the value recommended in
 	// the official GoDocs.
 	DefaultScryptP = 1
 )

--- a/internals/crypto/scrypt_test.go
+++ b/internals/crypto/scrypt_test.go
@@ -321,7 +321,7 @@ func TestIsPowerOfTwo(t *testing.T) {
 	}
 }
 
-// Below we test the assumption that increasing the salt lenght does
+// Below we test the assumption that increasing the salt length does
 // not significantly increase the execution time of key derivation
 // function. The output of the benchmarks is documented below:
 //

--- a/pkg/secrethub/account.go
+++ b/pkg/secrethub/account.go
@@ -42,7 +42,7 @@ func (s accountService) Keys() AccountKeyService {
 // createAccountKey creates a new intermediate key wrapped in the supplied credential.
 // The public key of the intermediate key is returned.
 // The intermediate key is returned in an CreateAccountKeyRequest ready to be sent to the API.
-// If an error has occured, it will be returned and the other result should be considered invalid.
+// If an error has occurred, it will be returned and the other result should be considered invalid.
 func (c *client) createAccountKeyRequest(credential Credential, accountKey crypto.RSAPrivateKey) (*api.CreateAccountKeyRequest, error) {
 	publicAccountKey, err := accountKey.Public().Export()
 	if err != nil {

--- a/pkg/secrethub/org_test.go
+++ b/pkg/secrethub/org_test.go
@@ -38,7 +38,7 @@ func TestCreateOrg(t *testing.T) {
 		Description: descr,
 		CreatedAt:   now,
 		Members: []*api.OrgMember{
-			&api.OrgMember{
+			{
 				OrgID:         orgID,
 				AccountID:     accountID,
 				Role:          "admin",

--- a/pkg/secrethub/user_test.go
+++ b/pkg/secrethub/user_test.go
@@ -15,6 +15,12 @@ import (
 	"github.com/secrethub/secrethub-go/internals/crypto"
 )
 
+const (
+	username = "dev1"
+	fullName = "Developer Uno"
+	email    = "dev1@testing.com"
+)
+
 func TestSignup(t *testing.T) {
 
 	// Arrange
@@ -24,10 +30,6 @@ func TestSignup(t *testing.T) {
 	userService := userService{
 		client: newClient(cred1, opts),
 	}
-
-	username := "dev1"
-	fullName := "Developer Uno"
-	email := "dev1@testing.com"
 
 	expectedCreateUserRequest := api.CreateUserRequest{
 		Username: username,
@@ -155,10 +157,6 @@ func TestGetUser(t *testing.T) {
 		newClient(cred1, opts),
 	)
 
-	username := "dev1"
-	fullName := "Developer Uno"
-	email := "dev1@testing.com"
-
 	now := time.Now().UTC()
 	expectedResponse := &api.User{
 		AccountID:   uuid.New(),
@@ -240,10 +238,6 @@ func TestGetMyUser(t *testing.T) {
 	userService := newUserService(
 		newClient(cred1, opts),
 	)
-
-	username := "dev1"
-	fullName := "Developer Uno"
-	email := "dev1@testing.com"
 
 	now := time.Now().UTC()
 	expected := &api.User{


### PR DESCRIPTION
Add the following linters:

  - unused
  - gosimple
  - stylecheck
  - structcheck
  - varcheck
  - interfacer
  - unconvert
  - ineffassign
  - deadcode
  - gocyclo
  - typecheck
  - depguard
  - unparam
  - nakedret
  - gofmt
  - misspell
  - prealloc
  - goconst

The last four found issues, which I've fixed.