### PR TITLE
Make the fields of CiphertextRSAAES public

### DIFF
--- a/internals/crypto/ciphertext_test.go
+++ b/internals/crypto/ciphertext_test.go
@@ -36,7 +36,7 @@ func TestRSAAES_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if bytes.Equal(ciphertext.aes.Data, input) {
+	if bytes.Equal(ciphertext.AES.Data, input) {
 		t.Error("encrypted data equals the original data")
 	}
 

--- a/internals/crypto/rsa.go
+++ b/internals/crypto/rsa.go
@@ -73,8 +73,8 @@ func (pub RSAPublicKey) Encrypt(data []byte) (CiphertextRSAAES, error) {
 	}
 
 	return CiphertextRSAAES{
-		aes: aesData,
-		rsa: rsaData,
+		AES: aesData,
+		RSA: rsaData,
 	}, nil
 }
 
@@ -229,12 +229,12 @@ func NewRSAPrivateKey(privateKey *rsa.PrivateKey) RSAPrivateKey {
 // then uses the decrypted symmetric key to decrypt the rest of the ciphertext
 // with the AES-GCM algorithm.
 func (prv RSAPrivateKey) Decrypt(ciphertext CiphertextRSAAES) ([]byte, error) {
-	aesKeyData, err := prv.Unwrap(ciphertext.rsa)
+	aesKeyData, err := prv.Unwrap(ciphertext.RSA)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewSymmetricKey(aesKeyData).Decrypt(ciphertext.aes)
+	return NewSymmetricKey(aesKeyData).Decrypt(ciphertext.AES)
 }
 
 // Unwrap uses the private key to decrypt a small ciphertext that has been encrypted
@@ -354,17 +354,17 @@ func (prv RSAPrivateKey) ExportPrivateKeyWithPassphrase(pass string) ([]byte, er
 
 // CiphertextRSAAES represents data encrypted with AES-GCM, where the AES key is encrypted with RSA-OAEP.
 type CiphertextRSAAES struct {
-	aes CiphertextAES
-	rsa CiphertextRSA
+	AES CiphertextAES
+	RSA CiphertextRSA
 }
 
 // EncodeToString encodes the ciphertext in a string.
 func (ct CiphertextRSAAES) EncodeToString() string {
-	data := base64.StdEncoding.EncodeToString(ct.aes.Data)
+	data := base64.StdEncoding.EncodeToString(ct.AES.Data)
 
 	metadata := newEncodedCiphertextMetadata(map[string]string{
-		"nonce": base64.StdEncoding.EncodeToString(ct.aes.Nonce),
-		"key":   base64.StdEncoding.EncodeToString(ct.rsa.Data),
+		"nonce": base64.StdEncoding.EncodeToString(ct.AES.Nonce),
+		"key":   base64.StdEncoding.EncodeToString(ct.RSA.Data),
 	})
 
 	return fmt.Sprintf("%s$%s$%s", algorithmRSAAES, data, metadata)
@@ -412,11 +412,11 @@ func DecodeCiphertextRSAAESFromString(s string) (CiphertextRSAAES, error) {
 	}
 
 	return CiphertextRSAAES{
-		aes: CiphertextAES{
+		AES: CiphertextAES{
 			Data:  encryptedData,
 			Nonce: aesNonce,
 		},
-		rsa: CiphertextRSA{
+		RSA: CiphertextRSA{
 			Data: aesKey,
 		},
 	}, nil

--- a/internals/crypto/symmetric_test.go
+++ b/internals/crypto/symmetric_test.go
@@ -95,11 +95,11 @@ func TestCiphertextRSAAES_MarshalJSON(t *testing.T) {
 	}{
 		"success": {
 			ciphertext: CiphertextRSAAES{
-				aes: CiphertextAES{
+				AES: CiphertextAES{
 					Data:  []byte("aes_data"),
 					Nonce: []byte("nonce_data"),
 				},
-				rsa: CiphertextRSA{
+				RSA: CiphertextRSA{
 					Data: []byte("rsa_data"),
 				},
 			},


### PR DESCRIPTION
To make it possible to create them in other ways than decoding from a string.