### PR TITLE
Add secrethub.DefaultCredentialParser

### DIFF
--- a/pkg/secrethub/credential.go
+++ b/pkg/secrethub/credential.go
@@ -66,9 +66,7 @@ type Credential interface {
 // a credential (e.g. to prompt only for a passphrase when the credential is encrypted),
 // it is recommended you use a CredentialParser instead (e.g. DefaultCredentialParser).
 func NewCredential(credential string, passphrase string) (Credential, error) {
-	parser := NewCredentialParser(DefaultCredentialDecoders)
-
-	encoded, err := parser.Parse(credential)
+	encoded, err := DefaultCredentialParser.Parse(credential)
 	if err != nil {
 		return nil, errio.Error(err)
 	}

--- a/pkg/secrethub/credential.go
+++ b/pkg/secrethub/credential.go
@@ -31,6 +31,8 @@ var (
 )
 
 var (
+	// DefaultCredentialParser defines the default parser for credentials.
+	DefaultCredentialParser = NewCredentialParser(DefaultCredentialDecoders)
 	// DefaultCredentialDecoders defines the default list of supported decoders.
 	DefaultCredentialDecoders = []CredentialDecoder{RSAPrivateKeyDecoder{}}
 	// DefaultCredentialEncoding defines the default encoding used for encoding credential segments.
@@ -59,6 +61,10 @@ type Credential interface {
 // NewCredential is a shorthand function to decode a credential string and optionally
 // decrypt it with a passphrase. When an encrypted credential is given, the passphrase
 // cannot be empty.
+//
+// Note that when you want to customize the process of parsing and decoding/decrypting
+// a credential (e.g. to prompt only for a passphrase when the credential is encrypted),
+// it is recommended you use a CredentialParser instead (e.g. DefaultCredentialParser).
 func NewCredential(credential string, passphrase string) (Credential, error) {
 	parser := NewCredentialParser(DefaultCredentialDecoders)
 


### PR DESCRIPTION
It's a convenience variable that makes the developer experience
simpler and shorter. Before the developer was required to type:

```go
parser := secrethub.NewCredentialParser(secrethub.DefaultCredentialEncoders)
encoded, err := parser.Parse(credential)
```

Now the developer can just use this one line without having to think
about encoders:

```go
encoded, err := secrethub.DefaultCredentialParser.Parse(credential)
```