### PR TITLE
EncryptedData API type for account keys

### DIFF
--- a/internals/api/account_key.go
+++ b/internals/api/account_key.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"net/http"
-
-	"github.com/secrethub/secrethub-go/internals/crypto"
 )
 
 // Errors
@@ -14,22 +12,25 @@ var (
 
 // EncryptedAccountKey represents an account key encrypted with a credential.
 type EncryptedAccountKey struct {
-	Account             *Account
-	PublicKey           []byte
-	EncryptedPrivateKey crypto.CiphertextRSAAES
-	Credential          *Credential
+	Account             *Account       `json:"account"`
+	PublicKey           []byte         `json:"public_key"`
+	EncryptedPrivateKey *EncryptedData `json:"encrypted_private_key"`
+	Credential          *Credential    `json:"credential"`
 }
 
 // CreateAccountKeyRequest contains the fields to add an account_key encrypted for a credential.
 type CreateAccountKeyRequest struct {
-	EncryptedPrivateKey crypto.CiphertextRSAAES
-	PublicKey           []byte
+	EncryptedPrivateKey *EncryptedData `json:"encrypted_private_key"`
+	PublicKey           []byte         `json:"public_key"`
 }
 
 // Validate checks whether the request is valid.
 func (req CreateAccountKeyRequest) Validate() error {
 	if len(req.PublicKey) == 0 {
 		return ErrInvalidPublicKey
+	}
+	if err := req.EncryptedPrivateKey.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internals/api/encrypted_data.go
+++ b/internals/api/encrypted_data.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 // Errors
@@ -11,8 +10,6 @@ var (
 	ErrInvalidKeyType             = errAPI.Code("invalid_key_type").Error("invalid key type")
 	ErrKeyAlgorithmMismatch       = errAPI.Code("key_algorithm_mismatch").Error("mismatch between algorithm and key type")
 	ErrInvalidKeyLength           = errAPI.Code("invalid_key_length").Error("key length value is invalid")
-	errWrongKeyType               = errors.New("key type field set to wrong value, refer to the documentation to construct a legal struct")
-	errInvalidEncryptedData       = errors.New("invalid EncryptedData struct was constructed, refer to the documentation to construct a legal struct")
 )
 
 // EncryptionAlgorithm specifies the encryption algorithm used for EncryptedData.

--- a/internals/api/encrypted_data.go
+++ b/internals/api/encrypted_data.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// Errors
+var (
+	ErrInvalidEncryptionAlgorithm = errAPI.Code("invalid_encryption_algorithm").Error("invalid encryption algorithm provided")
+	ErrInvalidKeyType             = errAPI.Code("invalid_key_type").Error("invalid key type")
+	ErrKeyAlgorithmMismatch       = errAPI.Code("key_algorithm_mismatch").Error("mismatch between algorithm and key type")
+	ErrInvalidKeyLength           = errAPI.Code("invalid_key_length").Error("key length value is invalid")
+	errWrongKeyType               = errors.New("key type field set to wrong value, refer to the documentation to construct a legal struct")
+	errInvalidEncryptedData       = errors.New("invalid EncryptedData struct was constructed, refer to the documentation to construct a legal struct")
+)
+
+// EncryptionAlgorithm specifies the encryption algorithm used for EncryptedData.
+type EncryptionAlgorithm string
+type HashingAlgorithm string
+
+// Supported values for EncryptionAlgorithm.
+const (
+	EncryptionAlgorithmAESGCM  EncryptionAlgorithm = "aes-gcm"
+	EncryptionAlgorithmRSAOEAP EncryptionAlgorithm = "rsa-oaep"
+	EncryptionAlgorithmAWSKMS  EncryptionAlgorithm = "aws-kms"
+
+	HashingAlgorithmSHA256 HashingAlgorithm = "sha-256"
+)
+
+// EncryptedData contains data that is encrypted with an algorithm described by Algorithm.
+// If the encryption method requires metadata, this is contained in Metadata.
+type EncryptedData struct {
+	Algorithm  EncryptionAlgorithm `json:"algorithm"`
+	Key        interface{}         `json:"key"`
+	Parameters interface{}         `json:"parameters,omitempty"`
+	Metadata   interface{}         `json:"metadata,omitempty"`
+	Ciphertext []byte              `json:"ciphertext"`
+}
+
+func NewEncryptedDataAESGCM(ciphertext, nonce []byte, nonceLength int, key interface{}) *EncryptedData {
+	return &EncryptedData{
+		Algorithm: EncryptionAlgorithmAESGCM,
+		Key:       key,
+		Metadata: &EncryptionMetadataAESGCM{
+			Nonce: nonce,
+		},
+		Parameters: &EncryptionParametersAESGCM{
+			NonceLength: &nonceLength,
+		},
+		Ciphertext: ciphertext,
+	}
+}
+
+func NewEncryptedDataRSAOAEP(ciphertext []byte, hashingAlgorithm HashingAlgorithm, key interface{}) *EncryptedData {
+	return &EncryptedData{
+		Algorithm: EncryptionAlgorithmRSAOEAP,
+		Key:       key,
+		Metadata:  &EncryptionMetadataRSAOEAP{},
+		Parameters: &EncryptionParametersRSAOAEP{
+			HashingAlgorithm: hashingAlgorithm,
+		},
+		Ciphertext: ciphertext,
+	}
+}
+
+func NewEncryptedDataAWSKMS(ciphertext []byte, key *EncryptionKeyAWS) *EncryptedData {
+	return &EncryptedData{
+		Algorithm:  EncryptionAlgorithmAWSKMS,
+		Key:        key,
+		Metadata:   &EncryptionMetadataAWSKMS{},
+		Parameters: &EncryptionParametersAWSKMS{},
+		Ciphertext: ciphertext,
+	}
+}
+
+// UnmarshalJSON populates an EncryptedData from a JSON representation.
+func (ed *EncryptedData) UnmarshalJSON(b []byte) error {
+	// Declare a private type to avoid recursion into this function.
+	type encryptedData EncryptedData
+
+	var rawKey, rawParameters, rawMetadata json.RawMessage
+	dec := encryptedData{
+		Key:        &rawKey,
+		Parameters: &rawParameters,
+		Metadata:   &rawMetadata,
+	}
+	err := json.Unmarshal(b, &dec)
+	if err != nil {
+		return err
+	}
+	if rawKey == nil {
+		return ErrInvalidKeyType
+	}
+	var keyType struct {
+		Type KeyType `json:"type"`
+	}
+	err = json.Unmarshal(rawKey, &keyType)
+	if err != nil {
+		return err
+	}
+
+	switch keyType.Type {
+	case KeyTypeDerived:
+		dec.Key = &EncryptionKeyDerived{}
+	case KeyTypeEncrypted:
+		dec.Key = &EncryptionKeyEncrypted{}
+	case KeyTypeAccountKey:
+		dec.Key = &EncryptionKeyAccountKey{}
+	case KeyTypeSecretKey:
+		dec.Key = &EncryptionKeySecretKey{}
+	case KeyTypeAWS:
+		dec.Key = &EncryptionKeyAWS{}
+	default:
+		return ErrInvalidKeyType
+	}
+	err = json.Unmarshal(rawKey, dec.Key)
+	if err != nil {
+		return err
+	}
+
+	switch dec.Algorithm {
+	case EncryptionAlgorithmRSAOEAP:
+		dec.Metadata = &EncryptionMetadataRSAOEAP{}
+		dec.Parameters = &EncryptionParametersRSAOAEP{}
+	case EncryptionAlgorithmAESGCM:
+		dec.Metadata = &EncryptionMetadataAESGCM{}
+		dec.Parameters = &EncryptionParametersAESGCM{}
+	case EncryptionAlgorithmAWSKMS:
+		dec.Metadata = &EncryptionMetadataAWSKMS{}
+		dec.Parameters = &EncryptionParametersAWSKMS{}
+	default:
+		return ErrInvalidEncryptionAlgorithm
+	}
+
+	if rawMetadata != nil {
+		err = json.Unmarshal(rawMetadata, dec.Metadata)
+		if err != nil {
+			return err
+		}
+	}
+	if rawParameters != nil {
+		err = json.Unmarshal(rawParameters, dec.Parameters)
+		if err != nil {
+			return err
+		}
+	}
+	*ed = EncryptedData(dec)
+	return nil
+}
+
+type validator interface {
+	Validate() error
+}
+
+type keyValidator interface {
+	validator
+	AlgorithmSupported(EncryptionAlgorithm) bool
+}
+
+func (ed *EncryptedData) Validate() error {
+	if ed.Algorithm != EncryptionAlgorithmAESGCM &&
+		ed.Algorithm != EncryptionAlgorithmRSAOEAP &&
+		ed.Algorithm != EncryptionAlgorithmAWSKMS {
+		return ErrInvalidEncryptionAlgorithm
+	}
+
+	if ed.Key == nil {
+		return ErrMissingField("key")
+	}
+	if ed.Parameters == nil {
+		return ErrMissingField("parameters")
+	}
+	if ed.Metadata == nil {
+		return ErrMissingField("parameters")
+	}
+	if ed.Ciphertext == nil {
+		return ErrMissingField("ciphertext")
+	}
+
+	key, ok := ed.Key.(keyValidator)
+	if !ok {
+		// TODO: or do we just want to panic here? This should never fail when the code is used correctly.
+		return errInvalidEncryptedData
+	}
+	if err := key.Validate(); err != nil {
+		return err
+	}
+	if !key.AlgorithmSupported(ed.Algorithm) {
+		return ErrKeyAlgorithmMismatch
+	}
+
+	parameters, ok := ed.Parameters.(validator)
+	if !ok {
+		// TODO: or do we just want to panic here? This should never fail when the code is used correctly.
+		return errInvalidEncryptedData
+	}
+	if err := parameters.Validate(); err != nil {
+		return err
+	}
+
+	metadata, ok := ed.Metadata.(validator)
+	if !ok {
+		// TODO: or do we just want to panic here? This should never fail when the code is used correctly.
+		return errInvalidEncryptedData
+	}
+	if err := metadata.Validate(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internals/api/encrypted_data.go
+++ b/internals/api/encrypted_data.go
@@ -105,6 +105,8 @@ func (ed *EncryptedData) UnmarshalJSON(b []byte) error {
 		dec.Key = &EncryptionKeyDerived{}
 	case KeyTypeEncrypted:
 		dec.Key = &EncryptionKeyEncrypted{}
+	case KeyTypeLocal:
+		dec.Key = &EncryptionKeyLocal{}
 	case KeyTypeAccountKey:
 		dec.Key = &EncryptionKeyAccountKey{}
 	case KeyTypeSecretKey:

--- a/internals/api/encrypted_data_test.go
+++ b/internals/api/encrypted_data_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/secrethub/secrethub-go/internals/assert"
 )
 
-func TestEncryptedData(t *testing.T) {
+func TestEncryptedData_MarshalUnmarshalValidate(t *testing.T) {
 	encryptedDataRSAAccountKey := NewEncryptedDataRSAOAEP([]byte("rsa-ciphertext"), HashingAlgorithmSHA256, NewEncryptionKeyAccountKey(4096, *uuid.New()))
 
 	cases := map[string]struct {

--- a/internals/api/encrypted_data_test.go
+++ b/internals/api/encrypted_data_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/secrethub/secrethub-go/internals/api/uuid"
+
+	"github.com/secrethub/secrethub-go/internals/assert"
+)
+
+func TestEncryptedData(t *testing.T) {
+	encryptedDataRSAAccountKey := NewEncryptedDataRSAOAEP([]byte("rsa-ciphertext"), HashingAlgorithmSHA256, NewEncryptionKeyAccountKey(4096, *uuid.New()))
+
+	cases := map[string]struct {
+		in          *EncryptedData
+		expectedErr error
+		validateErr error
+	}{
+		"aes with rsa account key": {
+			in: NewEncryptedDataAESGCM([]byte("ciphertext"), []byte("nonce"), 96, NewEncryptionKeyEncrypted(256, encryptedDataRSAAccountKey)),
+		},
+		"aes with secret key": {
+			in: NewEncryptedDataAESGCM([]byte("ciphertext"), []byte("nonce"), 96, NewEncryptionKeySecretKey(256, *uuid.New())),
+		},
+		"rsa account key": {
+			in: encryptedDataRSAAccountKey,
+		},
+		"aws kms": {
+			in: NewEncryptedDataAWSKMS([]byte("ciphertext"), NewEncryptionKeyAWS("arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab")),
+		},
+		"aes with scrypt": {
+			in:          NewEncryptedDataAESGCM([]byte("ciphertext"), []byte("nonce"), 96, NewEncryptionKeyDerivedScrypt(256, 1, 2, 3, []byte("just-a-salt"))),
+			expectedErr: errors.New("derived key type not yet supported"),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			bytes, err := json.Marshal(tc.in)
+			assert.OK(t, err)
+
+			var res EncryptedData
+			err = json.Unmarshal(bytes, &res)
+
+			assert.Equal(t, err, tc.expectedErr)
+			if tc.expectedErr == nil {
+				assert.Equal(t, res, tc.in)
+				assert.Equal(t, res.Validate(), tc.validateErr)
+			}
+		})
+	}
+}

--- a/internals/api/encrypted_data_test.go
+++ b/internals/api/encrypted_data_test.go
@@ -21,6 +21,9 @@ func TestEncryptedData(t *testing.T) {
 		"aes with rsa account key": {
 			in: NewEncryptedDataAESGCM([]byte("ciphertext"), []byte("nonce"), 96, NewEncryptionKeyEncrypted(256, encryptedDataRSAAccountKey)),
 		},
+		"aes with rsa local key": {
+			in: NewEncryptedDataAESGCM([]byte("ciphertext"), []byte("nonce"), 96, NewEncryptionKeyLocal(256)),
+		},
 		"aes with secret key": {
 			in: NewEncryptedDataAESGCM([]byte("ciphertext"), []byte("nonce"), 96, NewEncryptionKeySecretKey(256, *uuid.New())),
 		},

--- a/internals/api/encryption_key.go
+++ b/internals/api/encryption_key.go
@@ -12,6 +12,7 @@ type KeyDerivationAlgorithm string
 const (
 	KeyTypeDerived    KeyType = "derived"
 	KeyTypeEncrypted  KeyType = "encrypted"
+	KeyTypeLocal      KeyType = "local"
 	KeyTypeAccountKey KeyType = "account-key"
 	KeyTypeSecretKey  KeyType = "secret-key"
 	KeyTypeAWS        KeyType = "aws"
@@ -96,6 +97,36 @@ func (k EncryptionKeyEncrypted) Validate() error {
 		return ErrInvalidKeyLength
 	}
 	return k.EncryptedKey.Validate()
+}
+
+func NewEncryptionKeyLocal(length int) *EncryptionKeyLocal {
+	return &EncryptionKeyLocal{
+		EncryptionKey: EncryptionKey{
+			Type: KeyTypeLocal,
+		},
+		Length: Int(length),
+	}
+}
+
+type EncryptionKeyLocal struct {
+	EncryptionKey
+	Length *int `json:"length"`
+}
+
+func (EncryptionKeyLocal) AlgorithmSupported(a EncryptionAlgorithm) bool {
+	return a == EncryptionAlgorithmAESGCM || a == EncryptionAlgorithmRSAOEAP
+}
+func (k EncryptionKeyLocal) Validate() error {
+	if k.Type != KeyTypeLocal {
+		return errWrongKeyType
+	}
+	if k.Length == nil {
+		return ErrMissingField("length")
+	}
+	if *k.Length <= 0 {
+		return ErrInvalidKeyLength
+	}
+	return nil
 }
 
 func NewEncryptionKeyAccountKey(length int, id uuid.UUID) *EncryptionKeyAccountKey {

--- a/internals/api/encryption_key.go
+++ b/internals/api/encryption_key.go
@@ -90,7 +90,7 @@ func (k EncryptionKeyEncrypted) Validate() error {
 	if k.Length == nil {
 		return ErrMissingField("length")
 	}
-	if *k.Length <= 0 {
+	if IntValue(k.Length) <= 0 {
 		return ErrInvalidKeyLength
 	}
 	return k.EncryptedKey.Validate()

--- a/internals/api/encryption_key.go
+++ b/internals/api/encryption_key.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"errors"
+
+	"github.com/secrethub/secrethub-go/internals/api/uuid"
+)
+
+type KeyType string
+type KeyDerivationAlgorithm string
+
+const (
+	KeyTypeDerived    KeyType = "derived"
+	KeyTypeEncrypted  KeyType = "encrypted"
+	KeyTypeAccountKey KeyType = "account-key"
+	KeyTypeSecretKey  KeyType = "secret-key"
+	KeyTypeAWS        KeyType = "aws"
+
+	KeyDerivationAlgorithmScrypt KeyDerivationAlgorithm = "scrypt"
+)
+
+type EncryptionKey struct {
+	Type KeyType `json:"type"`
+}
+
+func NewEncryptionKeyDerivedScrypt(length, p, n, r int, salt []byte) *EncryptionKeyDerived {
+	return newEncryptionKeyDerived(
+		KeyDerivationAlgorithmScrypt,
+		length,
+		&KeyDerivationParametersScrypt{
+			P: Int(p),
+			N: Int(n),
+			R: Int(r),
+		},
+		&KeyDerivationMetadataScrypt{
+			Salt: salt,
+		},
+	)
+}
+
+func newEncryptionKeyDerived(algorithm KeyDerivationAlgorithm, length int, parameters, metadata interface{}) *EncryptionKeyDerived {
+	return &EncryptionKeyDerived{
+		EncryptionKey: EncryptionKey{
+			Type: KeyTypeDerived,
+		},
+		Length:     Int(length),
+		Algorithm:  algorithm,
+		Parameters: parameters,
+		Metadata:   metadata,
+	}
+}
+
+type EncryptionKeyDerived struct {
+	EncryptionKey
+	Length     *int                   `json:"length"`
+	Algorithm  KeyDerivationAlgorithm `json:"algorithm"`
+	Parameters interface{}            `json:"parameters,omitempty"`
+	Metadata   interface{}            `json:"metadata,omitempty"`
+}
+
+func (EncryptionKeyDerived) AlgorithmSupported(a EncryptionAlgorithm) bool {
+	return a == EncryptionAlgorithmAESGCM
+}
+func (EncryptionKeyDerived) Validate() error {
+	// TODO: implement
+	return nil
+}
+
+func NewEncryptionKeyEncrypted(length int, encryptedKey *EncryptedData) *EncryptionKeyEncrypted {
+	return &EncryptionKeyEncrypted{
+		EncryptionKey: EncryptionKey{
+			Type: KeyTypeEncrypted,
+		},
+		Length:       Int(length),
+		EncryptedKey: encryptedKey,
+	}
+}
+
+type EncryptionKeyEncrypted struct {
+	EncryptionKey
+	Length       *int           `json:"length"`
+	EncryptedKey *EncryptedData `json:"encrypted_key"`
+}
+
+func (EncryptionKeyEncrypted) AlgorithmSupported(a EncryptionAlgorithm) bool {
+	return a == EncryptionAlgorithmAESGCM || a == EncryptionAlgorithmRSAOEAP
+}
+func (k EncryptionKeyEncrypted) Validate() error {
+	if k.Type != KeyTypeEncrypted {
+		return errWrongKeyType
+	}
+	if k.Length == nil {
+		return ErrMissingField("length")
+	}
+	if *k.Length <= 0 {
+		return ErrInvalidKeyLength
+	}
+	return k.EncryptedKey.Validate()
+}
+
+func NewEncryptionKeyAccountKey(length int, id uuid.UUID) *EncryptionKeyAccountKey {
+	return &EncryptionKeyAccountKey{
+		EncryptionKey: EncryptionKey{
+			Type: KeyTypeAccountKey,
+		},
+		Length: Int(length),
+		ID:     &id,
+	}
+}
+
+type EncryptionKeyAccountKey struct {
+	EncryptionKey
+	Length *int       `json:"length"`
+	ID     *uuid.UUID `json:"id"`
+}
+
+func (EncryptionKeyAccountKey) AlgorithmSupported(a EncryptionAlgorithm) bool {
+	return a == EncryptionAlgorithmRSAOEAP
+}
+func (EncryptionKeyAccountKey) Validate() error {
+	// TODO: implement
+	return nil
+}
+
+func NewEncryptionKeySecretKey(length int, id uuid.UUID) *EncryptionKeySecretKey {
+	return &EncryptionKeySecretKey{
+		EncryptionKey: EncryptionKey{
+			Type: KeyTypeSecretKey,
+		},
+		Length: Int(length),
+		ID:     &id,
+	}
+}
+
+type EncryptionKeySecretKey struct {
+	EncryptionKey
+	Length *int       `json:"length"`
+	ID     *uuid.UUID `json:"id"`
+}
+
+func (EncryptionKeySecretKey) AlgorithmSupported(a EncryptionAlgorithm) bool {
+	return a == EncryptionAlgorithmAESGCM
+}
+func (EncryptionKeySecretKey) Validate() error {
+	// TODO: implement
+	return nil
+}
+
+func NewEncryptionKeyAWS(id string) *EncryptionKeyAWS {
+	return &EncryptionKeyAWS{
+		EncryptionKey: EncryptionKey{
+			Type: KeyTypeAWS,
+		},
+		ID: &id,
+	}
+}
+
+type EncryptionKeyAWS struct {
+	EncryptionKey
+	ID *string `json:"id"`
+}
+
+func (EncryptionKeyAWS) AlgorithmSupported(a EncryptionAlgorithm) bool {
+	return a == EncryptionAlgorithmAWSKMS
+}
+func (k EncryptionKeyAWS) Validate() error {
+	if k.Type != KeyTypeAWS {
+		return errWrongKeyType
+	}
+	if k.ID == nil {
+		return ErrMissingField("id")
+	}
+	return nil
+}
+
+type KeyDerivationParametersScrypt struct {
+	P *int `json:"p"`
+	N *int `json:"n"`
+	R *int `json:"r"`
+}
+
+func (KeyDerivationParametersScrypt) Validate() error {
+	return nil
+}
+
+type KeyDerivationMetadataScrypt struct {
+	Salt []byte `json:"salt"`
+}
+
+func (KeyDerivationMetadataScrypt) Validate() error {
+	return nil
+}
+
+func (ek *EncryptionKeyDerived) UnmarshalJSON(b []byte) error {
+	return errors.New("derived key type not yet supported")
+}

--- a/internals/api/encryption_key.go
+++ b/internals/api/encryption_key.go
@@ -87,9 +87,6 @@ func (EncryptionKeyEncrypted) AlgorithmSupported(a EncryptionAlgorithm) bool {
 	return a == EncryptionAlgorithmAESGCM || a == EncryptionAlgorithmRSAOEAP
 }
 func (k EncryptionKeyEncrypted) Validate() error {
-	if k.Type != KeyTypeEncrypted {
-		return errWrongKeyType
-	}
 	if k.Length == nil {
 		return ErrMissingField("length")
 	}
@@ -117,9 +114,6 @@ func (EncryptionKeyLocal) AlgorithmSupported(a EncryptionAlgorithm) bool {
 	return a == EncryptionAlgorithmAESGCM || a == EncryptionAlgorithmRSAOEAP
 }
 func (k EncryptionKeyLocal) Validate() error {
-	if k.Type != KeyTypeLocal {
-		return errWrongKeyType
-	}
 	if k.Length == nil {
 		return ErrMissingField("length")
 	}
@@ -195,9 +189,6 @@ func (EncryptionKeyAWS) AlgorithmSupported(a EncryptionAlgorithm) bool {
 	return a == EncryptionAlgorithmAWSKMS
 }
 func (k EncryptionKeyAWS) Validate() error {
-	if k.Type != KeyTypeAWS {
-		return errWrongKeyType
-	}
 	if k.ID == nil {
 		return ErrMissingField("id")
 	}

--- a/internals/api/encryption_metadata.go
+++ b/internals/api/encryption_metadata.go
@@ -7,15 +7,3 @@ type EncryptionMetadataAESGCM struct {
 func (EncryptionMetadataAESGCM) Validate() error {
 	return nil
 }
-
-type EncryptionMetadataRSAOEAP struct{}
-
-func (EncryptionMetadataRSAOEAP) Validate() error {
-	return nil
-}
-
-type EncryptionMetadataAWSKMS struct{}
-
-func (EncryptionMetadataAWSKMS) Validate() error {
-	return nil
-}

--- a/internals/api/encryption_metadata.go
+++ b/internals/api/encryption_metadata.go
@@ -1,0 +1,21 @@
+package api
+
+type EncryptionMetadataAESGCM struct {
+	Nonce []byte `json:"nonce"`
+}
+
+func (EncryptionMetadataAESGCM) Validate() error {
+	return nil
+}
+
+type EncryptionMetadataRSAOEAP struct{}
+
+func (EncryptionMetadataRSAOEAP) Validate() error {
+	return nil
+}
+
+type EncryptionMetadataAWSKMS struct{}
+
+func (EncryptionMetadataAWSKMS) Validate() error {
+	return nil
+}

--- a/internals/api/encryption_parameters.go
+++ b/internals/api/encryption_parameters.go
@@ -15,9 +15,3 @@ type EncryptionParametersRSAOAEP struct {
 func (EncryptionParametersRSAOAEP) Validate() error {
 	return nil
 }
-
-type EncryptionParametersAWSKMS struct{}
-
-func (EncryptionParametersAWSKMS) Validate() error {
-	return nil
-}

--- a/internals/api/encryption_parameters.go
+++ b/internals/api/encryption_parameters.go
@@ -1,0 +1,23 @@
+package api
+
+type EncryptionParametersAESGCM struct {
+	NonceLength *int `json:"nonce_length"`
+}
+
+func (EncryptionParametersAESGCM) Validate() error {
+	return nil
+}
+
+type EncryptionParametersRSAOAEP struct {
+	HashingAlgorithm HashingAlgorithm `json:"hashing_algorithm"`
+}
+
+func (EncryptionParametersRSAOAEP) Validate() error {
+	return nil
+}
+
+type EncryptionParametersAWSKMS struct{}
+
+func (EncryptionParametersAWSKMS) Validate() error {
+	return nil
+}

--- a/internals/api/values.go
+++ b/internals/api/values.go
@@ -10,3 +10,14 @@ func StringValue(val *string) string {
 	}
 	return ""
 }
+
+func Int(val int) *int {
+	return &val
+}
+
+func IntValue(val *int) int {
+	if val != nil {
+		return *val
+	}
+	return 0
+}

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -23,7 +23,7 @@ type Client interface {
 // Decrypter decrypts data, typically an account key.
 type Decrypter interface {
 	// Unwrap decrypts data, typically an account key.
-	Unwrap(ciphertext crypto.CiphertextRSAAES) ([]byte, error)
+	Unwrap(ciphertext *api.EncryptedData) ([]byte, error)
 }
 
 // Encrypter encrypts data, typically an account key.
@@ -31,7 +31,7 @@ type Encrypter interface {
 	// Fingerprint returns an identifier by which the server can identify the credential, e.g. a username of a fingerprint.
 	Fingerprint() (string, error)
 	// Wrap encrypts data, typically an account key.
-	Wrap(plaintext []byte) (crypto.CiphertextRSAAES, error)
+	Wrap(plaintext []byte) (*api.EncryptedData, error)
 }
 
 type clientAdapter struct {


### PR DESCRIPTION
Rewrite of https://github.com/secrethub/secrethub-go/pull/87 after spec session with @mackenbach.

Implements the following spec:
```json
// AES-GCM
{
    "algorithm": "aes-gcm",
    "parameters": {
        "nonce_length": 96,
    },
    "key": {
        "type": "secret_key",
        "length": 256,
        "id": "<secret key id>"
    },
    "metadata": {
        "nonce": "<nonce value>",
    },
    "ciphertext": "<ciphertext>",
},

// AES-GCM+SCRYPT
{
    "algorithm": "aes-gcm",
    "parameters": {
        "nonce_length": 96,
    },
    "key": {
        "type": "derived",
        "length": 256,
        "algorithm": "scrypt",
        "parameters": {
            "p": ,
            "r": ,
            "n": ,      
        },
        "metadata": {
            "salt": "<salt>"
        }
    },
    "metadata": {
        "nonce": "<nonce value>",
    },
    "ciphertext": "<ciphertext>",
},

// RSA-OAEP
{
    "algorithm": "rsa-oaep",
    "parameters": {
        "hashing_algorithm": "sha256"
    },
    "key": {
        "type": "account_key",
        "id": "<public-account-key-id>",        
        "length": 4096
    },
    "metadata": {},
    "ciphertext": "<ciphertext>",
},

// RSA-OAEP+AES-GCM
{
    "algorithm": "aes-gcm",
    "parameters" : {
        "nonce_length": 96,
    },
    "key": {
        "type": "encrypted",
        "length": 256,
        "encrypted_key": {
            "algorithm" : "rsa-oaep",
            "parameters": {
                "hashing_algorithm": "sha256"      
            },
            "key":{
                "type": "account_key",
                "id": "<account-key-id>",
                "length": 4096,
            },
            "metadata": {},
            "ciphertext": "<encrypted-key>"            
        }
    },
    "metadata": {
        "nonce": "<nonce value>",
    },
    "ciphertext": "<ciphertext>",
},

// AWS-KMS
{
    "algorithm": "aws-kms",
    "key": {
        "type": "aws",
        "id": "aws:kms:.../key/123456"
    },
    "ciphertext": "<ciphertext>",
},
```