### PR TITLE
Return RSACredential instead of Credential

### DIFF
--- a/pkg/secrethub/credential.go
+++ b/pkg/secrethub/credential.go
@@ -65,7 +65,7 @@ type Credential interface {
 // Note that when you want to customize the process of parsing and decoding/decrypting
 // a credential (e.g. to prompt only for a passphrase when the credential is encrypted),
 // it is recommended you use a CredentialParser instead (e.g. DefaultCredentialParser).
-func NewCredential(credential string, passphrase string) (Credential, error) {
+func NewCredential(credential string, passphrase string) (*RSACredential, error) {
 	encoded, err := DefaultCredentialParser.Parse(credential)
 	if err != nil {
 		return nil, errio.Error(err)

--- a/pkg/secrethub/main_test.go
+++ b/pkg/secrethub/main_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	cred1            RSACredential
+	cred1            *RSACredential
 	cred1PublicKey   []byte
 	cred1Fingerprint string
 	cred1Verifier    []byte


### PR DESCRIPTION
Since we are handling encoding and decoding here, passing around an interface is a pain. By saying these functions can only return RSACredential's, we remove a lot of the complexity. This is needed to make the CLI upgrade to the new version of secrethub-go a lot smoother.

In combination with https://github.com/secrethub/secrethub-cli/pull/104.

Tests still have to be fixed.