### PR TITLE
Add pkg/secretpath

### DIFF
--- a/pkg/secretpath/path.go
+++ b/pkg/secretpath/path.go
@@ -21,13 +21,6 @@ const (
 // Join joins any number of elements into a path, adding a separator
 // if necessary. Empty string elements are ignored.
 func Join(elements ...string) string {
-	switch len(elements) {
-	case 0:
-		return ""
-	case 1:
-		return strings.Trim(elements[0], elemSep)
-	}
-
 	result := ""
 	for _, e := range elements {
 		e = strings.Trim(e, elemSep)
@@ -38,7 +31,7 @@ func Join(elements ...string) string {
 		}
 	}
 
-	return result
+	return Clean(result)
 }
 
 // HasVersion returns true when a version suffix is specified in the path.
@@ -94,13 +87,13 @@ func AddVersion(path string, version int) string {
 		return path + suffix
 	}
 
-	return path[:i] + suffix
+	return Clean(path[:i] + suffix)
 }
 
 // Base returns the last element of a path. Trailing separators and version
 // numbers are removed.
 func Base(path string) string {
-	path = strings.Trim(path, elemSep)
+	path = Clean(path)
 
 	for i := len(path) - 1; i >= 0; i-- {
 		if path[i] == elemSepByte {
@@ -152,7 +145,7 @@ func Repo(path string) string {
 
 // Namespace returns the first element of a path, removing trailing separators.
 func Namespace(path string) string {
-	path = strings.Trim(path, elemSep)
+	path = Clean(path)
 	if len(path) == 0 {
 		return ""
 	}
@@ -172,6 +165,13 @@ func Namespace(path string) string {
 func Clean(path string) string {
 	if len(path) == 0 {
 		return ""
+	}
+
+	split := strings.SplitN(path, versionSep, 2)
+	path = split[0]
+	versionSuffix := ""
+	if len(split) > 1 {
+		versionSuffix = versionSep + split[1]
 	}
 
 	out := []byte{}
@@ -196,7 +196,7 @@ func Clean(path string) string {
 		out = append(out, path[i])
 	}
 
-	return string(out)
+	return string(out) + versionSuffix
 }
 
 // Count returns the number of elements in a path, excluding the version suffix.

--- a/pkg/secretpath/path.go
+++ b/pkg/secretpath/path.go
@@ -39,20 +39,17 @@ func Join(elements ...string) string {
 }
 
 // HasVersion returns true when a version suffix is specified in the path.
+// Note that even if the specified version suffix is invalid, this function 
+// still returns true.
 func HasVersion(path string) bool {
-	i := strings.LastIndex(path, versionSep)
-	return i >= 0 && i < len(path)-1
+	return strings.LastIndex(path, versionSep) >= 0  
 }
 
 // Version returns the version number suffix of a path, returning -1
-// when :latest or negative version numbers are given. If no version
-// suffix is set or it cannot be parsed to an integer, 0 is returned.
+// when :latest, no version suffix, or negative version numbers are 
+// given. If an invalid suffix is set, 0 is returned.
 func Version(path string) int {
-	if !HasVersion(path) {
-		return 0
-	}
-
-	if strings.HasSuffix(path, latestSuffix) {
+	if !HasVersion(path) || strings.HasSuffix(path, latestSuffix){
 		return -1
 	}
 

--- a/pkg/secretpath/path.go
+++ b/pkg/secretpath/path.go
@@ -40,11 +40,6 @@ func Join(elements ...string) string {
 
 // HasVersion returns true when a version suffix is specified in the path.
 func HasVersion(path string) bool {
-	return hasVersion(path)
-}
-
-// hasVersion returns true when a version suffix is specified in the path.
-func hasVersion(path string) bool {
 	i := strings.LastIndex(path, versionSep)
 	return i >= 0 && i < len(path)-1
 }
@@ -53,7 +48,7 @@ func hasVersion(path string) bool {
 // when :latest or negative version numbers are given. If no version
 // suffix is set or it cannot be parsed to an integer, 0 is returned.
 func Version(path string) int {
-	if !hasVersion(path) {
+	if !HasVersion(path) {
 		return 0
 	}
 

--- a/pkg/secretpath/path.go
+++ b/pkg/secretpath/path.go
@@ -39,17 +39,17 @@ func Join(elements ...string) string {
 }
 
 // HasVersion returns true when a version suffix is specified in the path.
-// Note that even if the specified version suffix is invalid, this function 
+// Note that even if the specified version suffix is invalid, this function
 // still returns true.
 func HasVersion(path string) bool {
-	return strings.LastIndex(path, versionSep) >= 0  
+	return strings.LastIndex(path, versionSep) >= 0
 }
 
 // Version returns the version number suffix of a path, returning -1
-// when :latest, no version suffix, or negative version numbers are 
+// when :latest, no version suffix, or negative version numbers are
 // given. If an invalid suffix is set, 0 is returned.
 func Version(path string) int {
-	if !HasVersion(path) || strings.HasSuffix(path, latestSuffix){
+	if !HasVersion(path) || strings.HasSuffix(path, latestSuffix) {
 		return -1
 	}
 

--- a/pkg/secretpath/path.go
+++ b/pkg/secretpath/path.go
@@ -1,0 +1,226 @@
+// Package secretpath implements utility functions for manipulating paths
+// compatible with SecretHub, e.g. namespaces, repositories, directories,
+// secrets and versions.
+package secretpath
+
+import (
+	"strconv"
+	"strings"
+
+	"bitbucket.org/zombiezen/cardcpx/natsort"
+)
+
+const (
+	elemSepByte    = '/'
+	elemSep        = string(elemSepByte)
+	versionSepByte = ':'
+	versionSep     = string(versionSepByte)
+	latestSuffix   = ":latest"
+)
+
+// Join joins any number of elements into a path, adding a separator
+// if necessary. Empty string elements are ignored.
+func Join(elements ...string) string {
+	switch len(elements) {
+	case 0:
+		return ""
+	case 1:
+		return strings.Trim(elements[0], elemSep)
+	}
+
+	result := ""
+	for _, e := range elements {
+		e = strings.Trim(e, elemSep)
+		if len(e) != 0 && len(result) == 0 {
+			result += e
+		} else if len(e) != 0 {
+			result += elemSep + e
+		}
+	}
+
+	return result
+}
+
+// HasVersion returns true when a version suffix is specified in the path.
+func HasVersion(path string) bool {
+	return hasVersion(path)
+}
+
+// hasVersion returns true when a version suffix is specified in the path.
+func hasVersion(path string) bool {
+	i := strings.LastIndex(path, versionSep)
+	return i >= 0 && i < len(path)-1
+}
+
+// Version returns the version number suffix of a path, returning -1
+// when :latest or negative version numbers are given. If no version
+// suffix is set or it cannot be parsed to an integer, 0 is returned.
+func Version(path string) int {
+	if !hasVersion(path) {
+		return 0
+	}
+
+	if strings.HasSuffix(path, latestSuffix) {
+		return -1
+	}
+
+	i := strings.LastIndex(path, versionSep)
+	version, err := strconv.Atoi(path[i+1:])
+	if err != nil {
+		return 0
+	}
+
+	if version < 0 {
+		return -1
+	}
+
+	return version
+}
+
+// AddVersion adds a version suffix to a given path, removing trailing
+// separators if necessary. If the path already contains a version suffix,
+// it is replaced by the given version number. Negative version numbers
+// are converted to ":latest".
+func AddVersion(path string, version int) string {
+	path = strings.Trim(path, elemSep)
+
+	suffix := latestSuffix
+	if version > 0 {
+		suffix = versionSep + strconv.Itoa(version)
+	}
+
+	i := strings.LastIndex(path, versionSep)
+	if i < 0 {
+		return path + suffix
+	}
+
+	return path[:i] + suffix
+}
+
+// Base returns the last element of a path. Trailing separators and version
+// numbers are removed.
+func Base(path string) string {
+	path = strings.Trim(path, elemSep)
+
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == elemSepByte {
+			return path[i+1:]
+		}
+
+		if path[i] == versionSepByte {
+			path = path[:i]
+		}
+	}
+	return path
+}
+
+// Parent returns all but the last element of a path, removing trailing separators.
+// If a path contains only one element, it returns an empty string.
+func Parent(path string) string {
+	path = Clean(path)
+
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == elemSepByte {
+			return path[:i]
+		}
+	}
+
+	return ""
+}
+
+// Repo returns the first two elements of a path, removing trailing separators.
+// If a path contains less than two elements, it returns the empty string.
+func Repo(path string) string {
+	path = Clean(path)
+
+	count := 0
+	for i := 0; i < len(path); i++ {
+		if path[i] == elemSepByte {
+			count++
+		}
+
+		if count == 2 {
+			return path[:i]
+		}
+	}
+
+	if count == 1 {
+		return path
+	}
+	return ""
+}
+
+// Namespace returns the first element of a path, removing trailing separators.
+func Namespace(path string) string {
+	path = strings.Trim(path, elemSep)
+	if len(path) == 0 {
+		return ""
+	}
+
+	for i := 0; i < len(path); i++ {
+		if path[i] == elemSepByte {
+			return path[:i]
+		}
+	}
+
+	return path
+}
+
+// Clean returns the shortest path name equivalent to the given path
+// by lexical processing. It removes trailing and multiple separator
+// elements. Version suffixes are not removed.
+func Clean(path string) string {
+	if len(path) == 0 {
+		return ""
+	}
+
+	out := []byte{}
+	previous := false
+	n := len(path)
+	for i := 0; i < n; i++ {
+		if path[i] == elemSepByte {
+			// Skip consecutive separators
+			if previous {
+				continue
+			}
+
+			previous = true
+
+			// Skip leading and trailing separators
+			if i == 0 || i == n-1 {
+				continue
+			}
+		} else {
+			previous = false
+		}
+		out = append(out, path[i])
+	}
+
+	return string(out)
+}
+
+// Count returns the number of elements in a path, excluding the version suffix.
+func Count(path string) int {
+	path = Clean(path)
+
+	if len(path) == 0 {
+		return 0
+	}
+
+	return 1 + strings.Count(path, elemSep)
+}
+
+// NaturalSort implements the sort.Interface by natural sorting.
+type NaturalSort []string
+
+func (s NaturalSort) Len() int {
+	return len(s)
+}
+
+func (s NaturalSort) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s NaturalSort) Less(i, j int) bool {
+	return natsort.Less(s[i], s[j])
+}

--- a/pkg/secretpath/path.go
+++ b/pkg/secretpath/path.go
@@ -24,9 +24,13 @@ func Join(elements ...string) string {
 	result := ""
 	for _, e := range elements {
 		e = strings.Trim(e, elemSep)
-		if len(e) != 0 && len(result) == 0 {
+		if len(e) == 0 {
+			continue
+		}
+
+		if len(result) == 0 {
 			result += e
-		} else if len(e) != 0 {
+		} else {
 			result += elemSep + e
 		}
 	}

--- a/pkg/secretpath/path.go
+++ b/pkg/secretpath/path.go
@@ -145,9 +145,6 @@ func Repo(path string) string {
 // Namespace returns the first element of a path, removing trailing separators.
 func Namespace(path string) string {
 	path = Clean(path)
-	if len(path) == 0 {
-		return ""
-	}
 
 	for i := 0; i < len(path); i++ {
 		if path[i] == elemSepByte {
@@ -162,10 +159,6 @@ func Namespace(path string) string {
 // by lexical processing. It removes trailing and multiple separator
 // elements. Version suffixes are not removed.
 func Clean(path string) string {
-	if len(path) == 0 {
-		return ""
-	}
-
 	split := strings.SplitN(path, versionSep, 2)
 	path = split[0]
 	versionSuffix := ""

--- a/pkg/secretpath/path_test.go
+++ b/pkg/secretpath/path_test.go
@@ -3,8 +3,8 @@ package secretpath_test
 import (
 	"testing"
 
-	"github.com/keylockerbv/secrethub-go/pkg/assert"
-	"github.com/keylockerbv/secrethub-go/pkg/secretpath"
+	"github.com/secrethub/secrethub-go/internals/assert"
+	"github.com/secrethub/secrethub-go/pkg/secretpath"
 )
 
 // TODO: implement these functions:

--- a/pkg/secretpath/path_test.go
+++ b/pkg/secretpath/path_test.go
@@ -299,6 +299,10 @@ func TestClean(t *testing.T) {
 		path     string
 		expected string
 	}{
+		"empty": {
+			path:     "",
+			expected: "",
+		},
 		"only sep": {
 			path:     "/",
 			expected: "",

--- a/pkg/secretpath/path_test.go
+++ b/pkg/secretpath/path_test.go
@@ -1,0 +1,467 @@
+package secretpath_test
+
+import (
+	"testing"
+
+	"github.com/keylockerbv/secrethub-go/pkg/assert"
+	"github.com/keylockerbv/secrethub-go/pkg/secretpath"
+)
+
+// TODO: implement these functions:
+// func Validate(path string) error {}
+// func IsSecret(path string) bool {}
+// func IsDir(path string) bool {}
+// func IsRepo(path string) bool {}
+// func IsNamespace(path string) bool {}
+
+func TestJoin(t *testing.T) {
+	cases := map[string]struct {
+		elem     []string
+		expected string
+	}{
+		"empty string": {
+			elem:     []string{""},
+			expected: "",
+		},
+		"zero": {
+			elem:     []string{},
+			expected: "",
+		},
+		"one": {
+			elem:     []string{"foo"},
+			expected: "foo",
+		},
+		"two": {
+			elem:     []string{"foo", "bar"},
+			expected: "foo/bar",
+		},
+		"empty string in the middle": {
+			elem:     []string{"foo", "", "bar"},
+			expected: "foo/bar",
+		},
+		"empty leading string": {
+			elem:     []string{"", "foo", "bar"},
+			expected: "foo/bar",
+		},
+		"with separator": {
+			elem:     []string{"foo/"},
+			expected: "foo",
+		},
+		"with separator in the middle": {
+			elem:     []string{"foo/", "bar"},
+			expected: "foo/bar",
+		},
+		"with separator arg": {
+			elem:     []string{"foo", "/", "bar"},
+			expected: "foo/bar",
+		},
+		"with version": {
+			elem:     []string{"foo", "bar:latest"},
+			expected: "foo/bar:latest",
+		},
+		"with separate version": {
+			elem:     []string{"foo", "bar", ":latest"},
+			expected: "foo/bar:latest",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.Join(tc.elem...)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}
+
+func TestBase(t *testing.T) {
+	cases := map[string]struct {
+		path     string
+		expected string
+	}{
+		"one element": {
+			path:     "foo",
+			expected: "foo",
+		},
+		"two elements": {
+			path:     "foo/bar",
+			expected: "bar",
+		},
+		"one element trailing separator": {
+			path:     "foo/",
+			expected: "foo",
+		},
+		"two elements trailing separator": {
+			path:     "foo/bar/",
+			expected: "bar",
+		},
+		"with version": {
+			path:     "foo/bar/baz:1",
+			expected: "baz",
+		},
+		"with latest version": {
+			path:     "foo/bar/baz:1",
+			expected: "baz",
+		},
+		"illegal": {
+			path:     "foo/illegal#$%",
+			expected: "illegal#$%",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.Base(tc.path)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}
+
+func TestParent(t *testing.T) {
+	cases := map[string]struct {
+		path     string
+		expected string
+	}{
+		"empty string": {
+			path:     "",
+			expected: "",
+		},
+		"separator only": {
+			path:     "/",
+			expected: "",
+		},
+		"one element": {
+			path:     "foo",
+			expected: "",
+		},
+		"two elements": {
+			path:     "foo/bar",
+			expected: "foo",
+		},
+		"two elements with version": {
+			path:     "foo/bar:1",
+			expected: "foo",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.Parent(tc.path)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}
+
+func TestHasVersion(t *testing.T) {
+	cases := map[string]struct {
+		path     string
+		expected bool
+	}{
+		"empty string": {
+			path:     "",
+			expected: false,
+		},
+		"one element": {
+			path:     "foo",
+			expected: false,
+		},
+		"two elements with version": {
+			path:     "foo/bar:1",
+			expected: true,
+		},
+		"numbered version": {
+			path:     "foo/bar/baz:1",
+			expected: true,
+		},
+		"latest version": {
+			path:     "foo/bar/baz:latest",
+			expected: true,
+		},
+		"empty version": {
+			path:     "foo/bar/baz:",
+			expected: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.HasVersion(tc.path)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}
+
+func TestVersion(t *testing.T) {
+	cases := map[string]struct {
+		path     string
+		expected int
+	}{
+		"empty string": {
+			path:     "",
+			expected: 0,
+		},
+		"one element": {
+			path:     "foo",
+			expected: 0,
+		},
+		"numbered version": {
+			path:     "foo/bar/baz:1",
+			expected: 1,
+		},
+		"multi-digit version": {
+			path:     "foo/bar/baz:12",
+			expected: 12,
+		},
+		"latest version": {
+			path:     "foo/bar/baz:latest",
+			expected: -1,
+		},
+		"negative version": {
+			path:     "foo/bar/baz:-3",
+			expected: -1,
+		},
+		"illegal text version": {
+			path:     "foo/bar/baz:illegal",
+			expected: 0,
+		},
+		"empty version": {
+			path:     "foo/bar/baz:",
+			expected: 0,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.Version(tc.path)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}
+
+func TestAddVersion(t *testing.T) {
+	cases := map[string]struct {
+		path     string
+		version  int
+		expected string
+	}{
+		"empty string": {
+			path:     "",
+			version:  1,
+			expected: ":1",
+		},
+		"one element": {
+			path:     "foo",
+			version:  1,
+			expected: "foo:1",
+		},
+		"two elements": {
+			path:     "foo/bar",
+			version:  1,
+			expected: "foo/bar:1",
+		},
+		"ends in separator": {
+			path:     "foo/bar/",
+			version:  1,
+			expected: "foo/bar:1",
+		},
+		"already has numbered version": {
+			path:     "foo/bar/baz:1",
+			version:  -1,
+			expected: "foo/bar/baz:latest",
+		},
+		"already has latest version": {
+			path:     "foo/bar/baz:latest",
+			version:  1,
+			expected: "foo/bar/baz:1",
+		},
+		"already has same version": {
+			path:     "foo/bar/baz:latest",
+			version:  -1,
+			expected: "foo/bar/baz:latest",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.AddVersion(tc.path, tc.version)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}
+
+func TestClean(t *testing.T) {
+	cases := map[string]struct {
+		path     string
+		expected string
+	}{
+		"only sep": {
+			path:     "/",
+			expected: "",
+		},
+		"only multiple sep": {
+			path:     "///",
+			expected: "",
+		},
+		"cleaned": {
+			path:     "foo/bar/baz",
+			expected: "foo/bar/baz",
+		},
+		"prefix": {
+			path:     "/foo/bar/baz",
+			expected: "foo/bar/baz",
+		},
+		"suffix": {
+			path:     "foo/bar/baz/",
+			expected: "foo/bar/baz",
+		},
+		"middle double": {
+			path:     "foo/bar//baz",
+			expected: "foo/bar/baz",
+		},
+		"middle triple": {
+			path:     "foo///bar/baz",
+			expected: "foo/bar/baz",
+		},
+		"version suffix": {
+			path:     "foo/bar//baz:latest",
+			expected: "foo/bar/baz:latest",
+		},
+		"version suffix with sep": {
+			path:     "foo/bar/baz/:latest",
+			expected: "foo/bar/baz:latest",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.Clean(tc.path)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}
+
+func TestCount(t *testing.T) {
+	cases := map[string]struct {
+		path     string
+		expected int
+	}{
+		"sempty string": {
+			path:     "",
+			expected: 0,
+		},
+		"separators only": {
+			path:     "/",
+			expected: 0,
+		},
+		"one": {
+			path:     "foo",
+			expected: 1,
+		},
+		"two": {
+			path:     "foo/bar",
+			expected: 2,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.Count(tc.path)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}
+
+func TestRepo(t *testing.T) {
+	cases := map[string]struct {
+		path     string
+		expected string
+	}{
+		"empty": {
+			path:     "",
+			expected: "",
+		},
+		"separator only": {
+			path:     "//",
+			expected: "",
+		},
+		"single element": {
+			path:     "foo",
+			expected: "",
+		},
+		"two elements": {
+			path:     "foo/bar",
+			expected: "foo/bar",
+		},
+		"single element with trailing separator": {
+			path:     "foo/",
+			expected: "",
+		},
+		"leading separator": {
+			path:     "/foo/bar",
+			expected: "foo/bar",
+		},
+		"leading separator three elements": {
+			path:     "/foo/bar/baz",
+			expected: "foo/bar",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.Repo(tc.path)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}
+
+func TestNamespace(t *testing.T) {
+	cases := map[string]struct {
+		path     string
+		expected string
+	}{
+		"empty": {
+			path:     "",
+			expected: "",
+		},
+		"separator only": {
+			path:     "//",
+			expected: "",
+		},
+		"single element": {
+			path:     "foo",
+			expected: "foo",
+		},
+		"multiple elements": {
+			path:     "foo/bar",
+			expected: "foo",
+		},
+		"single element with trailing separator": {
+			path:     "foo/",
+			expected: "foo",
+		},
+		"leading separator": {
+			path:     "/foo",
+			expected: "foo",
+		},
+		"leading separator multiple elements": {
+			path:     "/foo/bar",
+			expected: "foo",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := secretpath.Namespace(tc.path)
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}

--- a/pkg/secretpath/path_test.go
+++ b/pkg/secretpath/path_test.go
@@ -367,6 +367,10 @@ func TestCount(t *testing.T) {
 			path:     "foo/bar",
 			expected: 2,
 		},
+		"unclean": {
+			path:     "foo//bar",
+			expected: 2,
+		},
 	}
 
 	for name, tc := range cases {

--- a/pkg/secretpath/path_test.go
+++ b/pkg/secretpath/path_test.go
@@ -181,7 +181,7 @@ func TestHasVersion(t *testing.T) {
 		},
 		"empty version": {
 			path:     "foo/bar/baz:",
-			expected: false,
+			expected: true,
 		},
 	}
 
@@ -201,11 +201,11 @@ func TestVersion(t *testing.T) {
 	}{
 		"empty string": {
 			path:     "",
-			expected: 0,
+			expected: -1,
 		},
 		"one element": {
 			path:     "foo",
-			expected: 0,
+			expected: -1,
 		},
 		"numbered version": {
 			path:     "foo/bar/baz:1",
@@ -229,6 +229,10 @@ func TestVersion(t *testing.T) {
 		},
 		"empty version": {
 			path:     "foo/bar/baz:",
+			expected: 0,
+		},
+		"version 0": {
+			path:     "foo/bar/baz:0",
 			expected: 0,
 		},
 	}


### PR DESCRIPTION
This package implements utility functions for manipulating paths
compatible with SecretHub, e.g. namespaces, repositories, directories,
secrets and versions.

Had this one in the cooker for a while. Started it on a lazy sunday afternoon because I noticed we were doing quite some string manipulations in the Terraform provider and other projects that use the client library. 

The api.XXXPath types simply aren't usable enough so I tried to make something that is a bit more flexible. Inspired by Go's very own `filepath` [package](https://golang.org/pkg/path/filepath/).