### PR TITLE
Embed client in fake client

### DIFF
--- a/pkg/secrethub/fakeclient/client.go
+++ b/pkg/secrethub/fakeclient/client.go
@@ -13,6 +13,7 @@ type Client struct {
 	SecretService     *SecretService
 	ServiceService    *ServiceService
 	UserService       *UserService
+	secrethub.Client
 }
 
 // AccessRules implements the secrethub.Client interface.


### PR DESCRIPTION
So that the fake client always implements the client interface.

Tests that use functions that are not implemented on the fake will
fail with a nilpointer exception, while tests that do not use
unimplemented functions on the fake still compile and succeed.