### PR TITLE
Credential type rename

### DIFF
--- a/internals/api/credential.go
+++ b/internals/api/credential.go
@@ -52,8 +52,8 @@ type CredentialType string
 
 // Credential types
 const (
-	CredentialTypeRSA    CredentialType = "rsa"
-	CredentialTypeAWSSTS CredentialType = "aws-sts"
+	CredentialTypeKey CredentialType = "key"
+	CredentialTypeAWS CredentialType = "aws"
 )
 
 const (
@@ -63,7 +63,7 @@ const (
 
 // Validate validates whether the algorithm type is valid.
 func (a CredentialType) Validate() error {
-	if a == CredentialTypeRSA || a == CredentialTypeAWSSTS {
+	if a == CredentialTypeKey || a == CredentialTypeAWS {
 		return nil
 	}
 	return ErrInvalidCredentialType
@@ -98,10 +98,10 @@ func (req *CreateCredentialRequest) UnmarshalJSON(b []byte) error {
 	}
 
 	switch dec.Type {
-	case CredentialTypeAWSSTS:
-		dec.Proof = &CredentialProofAWSSTS{}
-	case CredentialTypeRSA:
-		dec.Proof = &CredentialProofRSA{}
+	case CredentialTypeAWS:
+		dec.Proof = &CredentialProofAWS{}
+	case CredentialTypeKey:
+		dec.Proof = &CredentialProofKey{}
 	default:
 		return ErrInvalidCredentialType
 	}
@@ -134,7 +134,7 @@ func (req *CreateCredentialRequest) Validate() error {
 		return err
 	}
 
-	if req.Type == CredentialTypeAWSSTS && req.Proof == nil {
+	if req.Type == CredentialTypeAWS && req.Proof == nil {
 		return ErrMissingField("proof")
 	}
 
@@ -146,10 +146,10 @@ func (req *CreateCredentialRequest) Validate() error {
 		return ErrInvalidFingerprint
 	}
 
-	if req.Type == CredentialTypeAWSSTS {
+	if req.Type == CredentialTypeAWS {
 		role, ok := req.Metadata[CredentialMetadataAWSRole]
 		if !ok {
-			return ErrMissingMetadata(CredentialMetadataAWSRole, CredentialTypeAWSSTS)
+			return ErrMissingMetadata(CredentialMetadataAWSRole, CredentialTypeAWS)
 		}
 		if !bytes.Equal(req.Verifier, []byte(role)) {
 			return ErrRoleDoesNotMatch
@@ -157,14 +157,14 @@ func (req *CreateCredentialRequest) Validate() error {
 
 		_, ok = req.Metadata[CredentialMetadataAWSKMSKey]
 		if !ok {
-			return ErrMissingMetadata(CredentialMetadataAWSKMSKey, CredentialTypeAWSSTS)
+			return ErrMissingMetadata(CredentialMetadataAWSKMSKey, CredentialTypeAWS)
 		}
 	}
 
 	for key := range req.Metadata {
 		if key != CredentialMetadataAWSKMSKey && key != CredentialMetadataAWSRole {
 			return ErrUnknownMetadataKey(key)
-		} else if req.Type != CredentialTypeAWSSTS {
+		} else if req.Type != CredentialTypeAWS {
 			return ErrInvalidMetadataKey(key, req.Type)
 		}
 	}
@@ -172,14 +172,14 @@ func (req *CreateCredentialRequest) Validate() error {
 	return nil
 }
 
-// CredentialProofAWSSTS is proof for when the credential type is AWSSTS.
-type CredentialProofAWSSTS struct {
+// CredentialProofAWS is proof for when the credential type is AWSSTS.
+type CredentialProofAWS struct {
 	Region  string `json:"region"`
 	Request []byte `json:"request"`
 }
 
-// Validate whether the CredentialProofAWSSTS is valid.
-func (p CredentialProofAWSSTS) Validate() error {
+// Validate whether the CredentialProofAWS is valid.
+func (p CredentialProofAWS) Validate() error {
 	if p.Region == "" {
 		return ErrMissingField("region")
 	}
@@ -189,13 +189,13 @@ func (p CredentialProofAWSSTS) Validate() error {
 	return nil
 }
 
-// CredentialProofRSA is proof for when the credential type is RSA.
-type CredentialProofRSA struct{}
+// CredentialProofKey is proof for when the credential type is RSA.
+type CredentialProofKey struct{}
 
 // GetFingerprint returns the fingerprint of a credential.
 func GetFingerprint(t CredentialType, verifier []byte) (string, error) {
 	var toHash []byte
-	if t == CredentialTypeRSA {
+	if t == CredentialTypeKey {
 		// Provide compatibility with traditional RSA credentials.
 		toHash = verifier
 	} else {

--- a/internals/api/credential.go
+++ b/internals/api/credential.go
@@ -39,7 +39,7 @@ const (
 // Credential is used to authenticate to the API and to encrypt the account key.
 type Credential struct {
 	AccountID   *uuid.UUID        `json:"account_id"`
-	Type        CredentialType    `json:"algorithm"`
+	Type        CredentialType    `json:"type"`
 	CreatedAt   time.Time         `json:"created_at"`
 	Fingerprint string            `json:"fingerprint"`
 	Name        string            `json:"name"`

--- a/internals/api/credential_test.go
+++ b/internals/api/credential_test.go
@@ -74,7 +74,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		"success aws": {
 			req: CreateCredentialRequest{
 				Type:        CredentialTypeAWS,
-				Fingerprint: "8eb80fb7b3cf1a3efc8c1afbbfb53cf371db6c8cef8947368d8f78a324d22462",
+				Fingerprint: "81e5c41692870d5f59875aa6bbd18d0099140795cb968824a2279d3d35095907",
 				Verifier:    []byte("arn:aws:iam::123456:role/path/to/role"),
 				Proof:       &CredentialProofAWS{},
 				Metadata: map[string]string{
@@ -87,7 +87,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		"aws role missing": {
 			req: CreateCredentialRequest{
 				Type:        CredentialTypeAWS,
-				Fingerprint: "8eb80fb7b3cf1a3efc8c1afbbfb53cf371db6c8cef8947368d8f78a324d22462",
+				Fingerprint: "81e5c41692870d5f59875aa6bbd18d0099140795cb968824a2279d3d35095907",
 				Verifier:    []byte("arn:aws:iam::123456:role/path/to/role"),
 				Proof:       &CredentialProofAWS{},
 				Metadata: map[string]string{
@@ -99,7 +99,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		"aws kms key missing": {
 			req: CreateCredentialRequest{
 				Type:        CredentialTypeAWS,
-				Fingerprint: "8eb80fb7b3cf1a3efc8c1afbbfb53cf371db6c8cef8947368d8f78a324d22462",
+				Fingerprint: "81e5c41692870d5f59875aa6bbd18d0099140795cb968824a2279d3d35095907",
 				Verifier:    []byte("arn:aws:iam::123456:role/path/to/role"),
 				Proof:       &CredentialProofAWS{},
 				Metadata: map[string]string{
@@ -123,7 +123,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		"extra metadata aws": {
 			req: CreateCredentialRequest{
 				Type:        CredentialTypeAWS,
-				Fingerprint: "8eb80fb7b3cf1a3efc8c1afbbfb53cf371db6c8cef8947368d8f78a324d22462",
+				Fingerprint: "81e5c41692870d5f59875aa6bbd18d0099140795cb968824a2279d3d35095907",
 				Verifier:    []byte("arn:aws:iam::123456:role/path/to/role"),
 				Proof:       &CredentialProofAWS{},
 				Metadata: map[string]string{

--- a/internals/api/credential_test.go
+++ b/internals/api/credential_test.go
@@ -14,7 +14,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		"success": {
 			req: CreateCredentialRequest{
 				Name:        "Personal laptop credential",
-				Type:        CredentialTypeRSA,
+				Type:        CredentialTypeKey,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 				Verifier:    []byte("verifier"),
 			},
@@ -22,7 +22,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"success without name": {
 			req: CreateCredentialRequest{
-				Type:        CredentialTypeRSA,
+				Type:        CredentialTypeKey,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 				Verifier:    []byte("verifier"),
 			},
@@ -30,7 +30,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"no fingerprint": {
 			req: CreateCredentialRequest{
-				Type:     CredentialTypeRSA,
+				Type:     CredentialTypeKey,
 				Name:     "Personal laptop credential",
 				Verifier: []byte("verifier"),
 			},
@@ -38,7 +38,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"invalid fingerprint": {
 			req: CreateCredentialRequest{
-				Type:        CredentialTypeRSA,
+				Type:        CredentialTypeKey,
 				Name:        "Personal laptop credential",
 				Fingerprint: "not-valid",
 				Verifier:    []byte("verifier"),
@@ -47,7 +47,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"empty verifier": {
 			req: CreateCredentialRequest{
-				Type:        CredentialTypeRSA,
+				Type:        CredentialTypeKey,
 				Name:        "Personal laptop credential",
 				Fingerprint: "fingerprint",
 				Verifier:    nil,
@@ -73,10 +73,10 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"success aws": {
 			req: CreateCredentialRequest{
-				Type:        CredentialTypeAWSSTS,
+				Type:        CredentialTypeAWS,
 				Fingerprint: "8eb80fb7b3cf1a3efc8c1afbbfb53cf371db6c8cef8947368d8f78a324d22462",
 				Verifier:    []byte("arn:aws:iam::123456:role/path/to/role"),
-				Proof:       &CredentialProofAWSSTS{},
+				Proof:       &CredentialProofAWS{},
 				Metadata: map[string]string{
 					CredentialMetadataAWSRole:   "arn:aws:iam::123456:role/path/to/role",
 					CredentialMetadataAWSKMSKey: "arn:aws:kms:us-east-1:123456:key/12345678-1234-1234-1234-123456789012",
@@ -86,32 +86,32 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"aws role missing": {
 			req: CreateCredentialRequest{
-				Type:        CredentialTypeAWSSTS,
+				Type:        CredentialTypeAWS,
 				Fingerprint: "8eb80fb7b3cf1a3efc8c1afbbfb53cf371db6c8cef8947368d8f78a324d22462",
 				Verifier:    []byte("arn:aws:iam::123456:role/path/to/role"),
-				Proof:       &CredentialProofAWSSTS{},
+				Proof:       &CredentialProofAWS{},
 				Metadata: map[string]string{
 					CredentialMetadataAWSKMSKey: "arn:aws:kms:us-east-1:123456:key/12345678-1234-1234-1234-123456789012",
 				},
 			},
-			err: ErrMissingMetadata(CredentialMetadataAWSRole, CredentialTypeAWSSTS),
+			err: ErrMissingMetadata(CredentialMetadataAWSRole, CredentialTypeAWS),
 		},
 		"aws kms key missing": {
 			req: CreateCredentialRequest{
-				Type:        CredentialTypeAWSSTS,
+				Type:        CredentialTypeAWS,
 				Fingerprint: "8eb80fb7b3cf1a3efc8c1afbbfb53cf371db6c8cef8947368d8f78a324d22462",
 				Verifier:    []byte("arn:aws:iam::123456:role/path/to/role"),
-				Proof:       &CredentialProofAWSSTS{},
+				Proof:       &CredentialProofAWS{},
 				Metadata: map[string]string{
 					CredentialMetadataAWSRole: "arn:aws:iam::123456:role/path/to/role",
 				},
 			},
-			err: ErrMissingMetadata(CredentialMetadataAWSKMSKey, CredentialTypeAWSSTS),
+			err: ErrMissingMetadata(CredentialMetadataAWSKMSKey, CredentialTypeAWS),
 		},
 		"extra metadata": {
 			req: CreateCredentialRequest{
 				Name:        "Personal laptop credential",
-				Type:        CredentialTypeRSA,
+				Type:        CredentialTypeKey,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 				Verifier:    []byte("verifier"),
 				Metadata: map[string]string{
@@ -122,10 +122,10 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"extra metadata aws": {
 			req: CreateCredentialRequest{
-				Type:        CredentialTypeAWSSTS,
+				Type:        CredentialTypeAWS,
 				Fingerprint: "8eb80fb7b3cf1a3efc8c1afbbfb53cf371db6c8cef8947368d8f78a324d22462",
 				Verifier:    []byte("arn:aws:iam::123456:role/path/to/role"),
-				Proof:       &CredentialProofAWSSTS{},
+				Proof:       &CredentialProofAWS{},
 				Metadata: map[string]string{
 					CredentialMetadataAWSRole:   "arn:aws:iam::123456:role/path/to/role",
 					CredentialMetadataAWSKMSKey: "arn:aws:kms:us-east-1:123456:key/12345678-1234-1234-1234-123456789012",

--- a/internals/api/user_test.go
+++ b/internals/api/user_test.go
@@ -190,7 +190,7 @@ func TestCreateUserRequest_Validate(t *testing.T) {
 				FullName: "Test Tester",
 				Credential: &CreateCredentialRequest{
 					Name:        "Personal laptop credential",
-					Type:        CredentialTypeRSA,
+					Type:        CredentialTypeKey,
 					Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 					Verifier:    []byte("verifier"),
 				},

--- a/internals/aws/service_creator.go
+++ b/internals/aws/service_creator.go
@@ -65,7 +65,7 @@ func NewCredentialCreator(keyID, role string, cfgs ...*aws.Config) (*CredentialC
 
 // Type returns the credential type of an AWS service.
 func (c CredentialCreator) Type() api.CredentialType {
-	return api.CredentialTypeAWSSTS
+	return api.CredentialTypeAWS
 }
 
 // Verifier returns the verifier of an AWS service.
@@ -88,7 +88,7 @@ func (c CredentialCreator) AddProof(req *api.CreateCredentialRequest) error {
 		return err
 	}
 
-	req.Proof = &api.CredentialProofAWSSTS{
+	req.Proof = &api.CredentialProofAWS{
 		Region:  c.signingRegion,
 		Request: encryptReq,
 	}

--- a/internals/aws/service_creator_test.go
+++ b/internals/aws/service_creator_test.go
@@ -38,13 +38,13 @@ func TestServiceCreator_AddProof(t *testing.T) {
 		signingRegion        string
 
 		expectedErr error
-		expected    *api.CredentialProofAWSSTS
+		expected    *api.CredentialProofAWS
 	}{
 		"success": {
 			encryptRequest: defaultRequest,
 			signingRegion:  defaultRegion,
 
-			expected: &api.CredentialProofAWSSTS{
+			expected: &api.CredentialProofAWS{
 				Region:  defaultRegion,
 				Request: defaultRequest,
 			},
@@ -80,7 +80,7 @@ func TestServiceCreator_AddProof(t *testing.T) {
 			if tc.expectedErr == nil {
 				assert.Equal(t, usedPlaintext, api.CredentialProofPrefixAWS+sc.role)
 
-				proof, ok := req.Proof.(*api.CredentialProofAWSSTS)
+				proof, ok := req.Proof.(*api.CredentialProofAWS)
 				assert.Equal(t, ok, true)
 				assert.Equal(t, proof, tc.expected)
 			}

--- a/pkg/secrethub/credentials/rsa.go
+++ b/pkg/secrethub/credentials/rsa.go
@@ -114,7 +114,7 @@ func (c RSACredential) Unwrap(ciphertext *api.EncryptedData) ([]byte, error) {
 
 // Type returns what type of credential this is.
 func (c RSACredential) Type() api.CredentialType {
-	return api.CredentialTypeRSA
+	return api.CredentialTypeKey
 }
 
 // AddProof add the proof for possession of this credential to a CreateCredentialRequest .

--- a/pkg/secrethub/user_test.go
+++ b/pkg/secrethub/user_test.go
@@ -36,10 +36,10 @@ func TestSignup(t *testing.T) {
 		FullName: fullName,
 		Email:    email,
 		Credential: &api.CreateCredentialRequest{
-			Type:        api.CredentialTypeRSA,
+			Type:        api.CredentialTypeKey,
 			Fingerprint: cred1Fingerprint,
 			Verifier:    cred1Verifier,
-			Proof:       &api.CredentialProofRSA{},
+			Proof:       &api.CredentialProofKey{},
 		},
 	}
 


### PR DESCRIPTION
Rename credential types as discussed last week.

The server contains compatibility code to maintain compatibility with clients `<=v0.20`.