### PR TITLE
Make created_by field of service non-optional

### DIFF
--- a/internals/api/service.go
+++ b/internals/api/service.go
@@ -30,7 +30,7 @@ type Service struct {
 	ServiceID   string      `json:"service_id"`
 	Repo        *Repo       `json:"repo"`
 	Description string      `json:"description"`
-	CreatedBy   *uuid.UUID  `json:"created_by,omitempty"`
+	CreatedBy   uuid.UUID   `json:"created_by"`
 	CreatedAt   time.Time   `json:"created_at"`
 	Credential  *Credential `json:"credential"`
 }


### PR DESCRIPTION
Use a value instead of pointer for created_by field of service,
as services are always created by an account. This field is not
optional.