### PR TITLE
Only add query params to request when not empty

### DIFF
--- a/pkg/secrethub/internals/http/client.go
+++ b/pkg/secrethub/internals/http/client.go
@@ -249,8 +249,8 @@ func (c *Client) AuditRepo(namespace, repoName string, subjectTypes api.AuditSub
 	out := []*api.Audit{}
 	rawURL := fmt.Sprintf(pathRepoEvents, c.base, namespace, repoName)
 	query := make(url.Values)
-	for _, subjectType := range subjectTypes {
-		query.Add("subject_types", string(subjectType))
+	if len(subjectTypes) > 0 {
+		query.Set("subject_types", subjectTypes.Join(","))
 	}
 	if len(query) > 0 {
 		rawURL += "?" + query.Encode()

--- a/pkg/secrethub/internals/http/client.go
+++ b/pkg/secrethub/internals/http/client.go
@@ -247,7 +247,14 @@ func (c *Client) DeleteRepo(namespace, repoName string) error {
 // AuditRepo gets the audit events for a given repo.
 func (c *Client) AuditRepo(namespace, repoName string, subjectTypes api.AuditSubjectTypeList) ([]*api.Audit, error) {
 	out := []*api.Audit{}
-	rawURL := fmt.Sprintf(pathRepoEvents+"?subject_types=%s", c.base, namespace, repoName, subjectTypes.Join(","))
+	rawURL := fmt.Sprintf(pathRepoEvents, c.base, namespace, repoName)
+	query := make(url.Values)
+	for _, subjectType := range subjectTypes {
+		query.Add("subject_types", string(subjectType))
+	}
+	if len(query) > 0 {
+		rawURL += "?" + query.Encode()
+	}
 	err := c.get(rawURL, true, &out)
 	return out, errio.Error(err)
 }


### PR DESCRIPTION
Don't add a query parameter when no subject types are given.

Request `/v1/namespaces/<workspace>/repos/<repo>/events` instead of `/v1/namespaces/<workspace>/repos/<repo>/events?subject_types=`.