### PR TITLE
Add CreateAll func to dir service to create dirs recursively

### DIFF
--- a/pkg/secrethub/dir.go
+++ b/pkg/secrethub/dir.go
@@ -190,6 +190,7 @@ func (s dirService) createAll(path string) error {
 
 	_, err := s.GetTree(path, 0, false)
 	if err != api.ErrDirNotFound {
+		// err might be nil
 		return err
 	}
 
@@ -202,6 +203,7 @@ func (s dirService) createAll(path string) error {
 	if err == api.ErrDirAlreadyExists {
 		return nil
 	}
+	// err might be nil
 	return err
 }
 

--- a/pkg/secrethub/dir.go
+++ b/pkg/secrethub/dir.go
@@ -14,6 +14,8 @@ type DirService interface {
 	// Create a directory at a given path.
 	Create(path string) (*api.Dir, error)
 	// CreateAll creates all directories in the given path that do not exist yet.
+	//
+	// Contrary to Create, it doesn't return an error when the directories already exist.
 	CreateAll(path string) error
 	// Get returns the directory with the given ID.
 	GetByID(id uuid.UUID) (*api.Dir, error)
@@ -175,6 +177,8 @@ func (s dirService) Delete(path string) error {
 }
 
 // CreateAll creates all directories in the given path that do not exist yet.
+//
+// Contrary to Create, it doesn't return an error when the directories already exist.
 func (s dirService) CreateAll(path string) error {
 	err := api.ValidateDirPath(path)
 	if err != nil {

--- a/pkg/secrethub/dir.go
+++ b/pkg/secrethub/dir.go
@@ -193,14 +193,16 @@ func (s dirService) createAll(path string) error {
 		return err
 	}
 
+	err = s.createAll(secretpath.Parent(path))
+	if err != nil {
+		return err
+	}
+
 	_, err = s.Create(path)
 	if err == api.ErrDirAlreadyExists {
 		return nil
 	}
-	if err != nil {
-		return err
-	}
-	return s.createAll(secretpath.Parent(path))
+	return err
 }
 
 // listDirAccounts list the accounts with read permission.


### PR DESCRIPTION
It works just like mkdir -p, creating all directories that do not
exist yet recursively and it does not error when the directories
already exist.