### PR TITLE
Allow setting the credential description for new credentials

### DIFF
--- a/internals/api/credential.go
+++ b/internals/api/credential.go
@@ -21,7 +21,7 @@ var (
 	ErrCredentialFingerprintNotUnique = errAPI.Code("fingerprint_not_unique").StatusErrorf("there are multiple credentials that start with the given fingerprint. Please use the full fingerprint", http.StatusConflict)
 	ErrInvalidVerifier                = errAPI.Code("invalid_verifier").StatusError("verifier is invalid", http.StatusBadRequest)
 	ErrInvalidCredentialType          = errAPI.Code("invalid_credential_type").StatusError("credential type is invalid", http.StatusBadRequest)
-	ErrInvalidCredentialName          = errAPI.Code("invalid_credential_name").StatusError("credential name must be between 1 and 20 characters long", http.StatusBadRequest)
+	ErrInvalidCredentialDescription   = errAPI.Code("invalid_credential_description").StatusError("credential description must be between 1 and 20 characters long", http.StatusBadRequest)
 	ErrInvalidAWSEndpoint             = errAPI.Code("invalid_aws_endpoint").StatusError("invalid AWS endpoint provided", http.StatusBadRequest)
 	ErrInvalidProof                   = errAPI.Code("invalid_proof").StatusError("invalid proof provided for credential", http.StatusUnauthorized)
 	ErrAWSAccountMismatch             = errAPI.Code("aws_account_mismatch").StatusError("the AWS Account ID in the role ARN does not match the AWS Account ID of the AWS credentials used for authentication. Make sure you are using AWS credentials that correspond to the role you are trying to add.", http.StatusUnauthorized)
@@ -51,7 +51,7 @@ type Credential struct {
 	Type        CredentialType    `json:"type"`
 	CreatedAt   time.Time         `json:"created_at"`
 	Fingerprint string            `json:"fingerprint"`
-	Name        string            `json:"name"`
+	Description string            `json:"description"`
 	Verifier    []byte            `json:"verifier"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 	Enabled     bool              `json:"enabled"`
@@ -89,7 +89,7 @@ func (a CredentialType) Validate() error {
 type CreateCredentialRequest struct {
 	Type        CredentialType           `json:"type"`
 	Fingerprint string                   `json:"fingerprint"`
-	Name        string                   `json:"name,omitempty"`
+	Description *string                  `json:"name,omitempty"`
 	Verifier    []byte                   `json:"verifier"`
 	Proof       interface{}              `json:"proof"`
 	Metadata    map[string]string        `json:"metadata"`
@@ -148,8 +148,8 @@ func (req *CreateCredentialRequest) Validate() error {
 		return ErrMissingField("type")
 	}
 
-	if req.Name != "" {
-		if err := ValidateCredentialName(req.Name); err != nil {
+	if req.Description != nil {
+		if err := ValidateCredentialDescription(*req.Description); err != nil {
 			return err
 		}
 	}

--- a/internals/api/credential.go
+++ b/internals/api/credential.go
@@ -21,7 +21,7 @@ var (
 	ErrCredentialFingerprintNotUnique = errAPI.Code("fingerprint_not_unique").StatusErrorf("there are multiple credentials that start with the given fingerprint. Please use the full fingerprint", http.StatusConflict)
 	ErrInvalidVerifier                = errAPI.Code("invalid_verifier").StatusError("verifier is invalid", http.StatusBadRequest)
 	ErrInvalidCredentialType          = errAPI.Code("invalid_credential_type").StatusError("credential type is invalid", http.StatusBadRequest)
-	ErrInvalidCredentialDescription   = errAPI.Code("invalid_credential_description").StatusError("credential description must be between 1 and 20 characters long", http.StatusBadRequest)
+	ErrInvalidCredentialDescription   = errAPI.Code("invalid_credential_description").StatusError("credential description can be at most 32 characters long", http.StatusBadRequest)
 	ErrInvalidAWSEndpoint             = errAPI.Code("invalid_aws_endpoint").StatusError("invalid AWS endpoint provided", http.StatusBadRequest)
 	ErrInvalidProof                   = errAPI.Code("invalid_proof").StatusError("invalid proof provided for credential", http.StatusUnauthorized)
 	ErrAWSAccountMismatch             = errAPI.Code("aws_account_mismatch").StatusError("the AWS Account ID in the role ARN does not match the AWS Account ID of the AWS credentials used for authentication. Make sure you are using AWS credentials that correspond to the role you are trying to add.", http.StatusUnauthorized)

--- a/internals/api/credential_test.go
+++ b/internals/api/credential_test.go
@@ -7,13 +7,23 @@ import (
 )
 
 func TestCreateCredentialRequest_Validate(t *testing.T) {
+	description := "Personal laptop credential"
+
 	cases := map[string]struct {
 		req CreateCredentialRequest
 		err error
 	}{
 		"success": {
 			req: CreateCredentialRequest{
-				Name:        "Personal laptop credential",
+				Description: &description,
+				Type:        CredentialTypeKey,
+				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
+				Verifier:    []byte("verifier"),
+			},
+			err: nil,
+		},
+		"success without description": {
+			req: CreateCredentialRequest{
 				Type:        CredentialTypeKey,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 				Verifier:    []byte("verifier"),
@@ -22,7 +32,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"success including account key": {
 			req: CreateCredentialRequest{
-				Name:        "Personal laptop credential",
+				Description: &description,
 				Type:        CredentialTypeKey,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 				Verifier:    []byte("verifier"),
@@ -35,7 +45,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"including invalid account key": {
 			req: CreateCredentialRequest{
-				Name:        "Personal laptop credential",
+				Description: &description,
 				Type:        CredentialTypeKey,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 				Verifier:    []byte("verifier"),
@@ -43,7 +53,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 			},
 			err: ErrInvalidPublicKey,
 		},
-		"success without name": {
+		"success without Description": {
 			req: CreateCredentialRequest{
 				Type:        CredentialTypeKey,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
@@ -53,16 +63,16 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"no fingerprint": {
 			req: CreateCredentialRequest{
-				Type:     CredentialTypeKey,
-				Name:     "Personal laptop credential",
-				Verifier: []byte("verifier"),
+				Type:        CredentialTypeKey,
+				Description: &description,
+				Verifier:    []byte("verifier"),
 			},
 			err: ErrMissingField("fingerprint"),
 		},
 		"invalid fingerprint": {
 			req: CreateCredentialRequest{
 				Type:        CredentialTypeKey,
-				Name:        "Personal laptop credential",
+				Description: &description,
 				Fingerprint: "not-valid",
 				Verifier:    []byte("verifier"),
 			},
@@ -71,7 +81,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		"empty verifier": {
 			req: CreateCredentialRequest{
 				Type:        CredentialTypeKey,
-				Name:        "Personal laptop credential",
+				Description: &description,
 				Fingerprint: "fingerprint",
 				Verifier:    nil,
 			},
@@ -79,7 +89,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"empty type": {
 			req: CreateCredentialRequest{
-				Name:        "Personal laptop credential",
+				Description: &description,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 				Verifier:    []byte("verifier"),
 			},
@@ -87,7 +97,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"invalid type": {
 			req: CreateCredentialRequest{
-				Name:        "Personal laptop credential",
+				Description: &description,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 				Verifier:    []byte("verifier"),
 				Type:        CredentialType("invalid"),
@@ -133,7 +143,7 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 		"extra metadata": {
 			req: CreateCredentialRequest{
-				Name:        "Personal laptop credential",
+				Description: &description,
 				Type:        CredentialTypeKey,
 				Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 				Verifier:    []byte("verifier"),
@@ -201,8 +211,8 @@ func TestCreateCredentialRequest_Validate(t *testing.T) {
 		},
 	}
 
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
+	for Description, tc := range cases {
+		t.Run(Description, func(t *testing.T) {
 			// Do
 			err := tc.req.Validate()
 

--- a/internals/api/patterns.go
+++ b/internals/api/patterns.go
@@ -258,13 +258,13 @@ func ValidateDirPath(path string) error {
 	return nil
 }
 
-// ValidateCredentialName validates the name for a credential.
-func ValidateCredentialName(name string) error {
-	if len(name) > 32 {
-		return ErrInvalidCredentialName
+// ValidateCredentialDescription validates the description for a credential.
+func ValidateCredentialDescription(description string) error {
+	if len(description) < 1 || len(description) > 32 {
+		return ErrInvalidCredentialDescription
 	}
-	if !whitelistDescription.MatchString(name) {
-		return ErrInvalidCredentialName
+	if !whitelistDescription.MatchString(description) {
+		return ErrInvalidCredentialDescription
 	}
 	return nil
 }

--- a/internals/api/user_test.go
+++ b/internals/api/user_test.go
@@ -189,7 +189,6 @@ func TestCreateUserRequest_Validate(t *testing.T) {
 				Email:    "test-account.dev1@secrethub.io",
 				FullName: "Test Tester",
 				Credential: &CreateCredentialRequest{
-					Name:        "Personal laptop credential",
 					Type:        CredentialTypeKey,
 					Fingerprint: "88c9eae68eb300b2971a2bec9e5a26ff4179fd661d6b7d861e4c6557b9aaee14",
 					Verifier:    []byte("verifier"),

--- a/pkg/secrethub/credentials.go
+++ b/pkg/secrethub/credentials.go
@@ -8,7 +8,7 @@ import (
 // CredentialService handles operations on credentials on SecretHub.
 type CredentialService interface {
 	// Create a new credential from the credentials.Creator for an existing account.
-	Create(credentials.Creator) error
+	Create(string, credentials.Creator) error
 	// Disable an existing credential.
 	Disable(fingerprint string) error
 }
@@ -25,7 +25,7 @@ type credentialService struct {
 
 // Create a new credential from the credentials.Creator for an existing account.
 // This includes a re-encrypted copy the the account key.
-func (s credentialService) Create(creator credentials.Creator) error {
+func (s credentialService) Create(name string, creator credentials.Creator) error {
 	accountKey, err := s.client.getAccountKey()
 	if err != nil {
 		return err
@@ -48,6 +48,7 @@ func (s credentialService) Create(creator credentials.Creator) error {
 	}
 
 	req := api.CreateCredentialRequest{
+		Name:        name,
 		Fingerprint: fingerprint,
 		Verifier:    bytes,
 		Type:        verifier.Type(),

--- a/pkg/secrethub/credentials.go
+++ b/pkg/secrethub/credentials.go
@@ -8,7 +8,7 @@ import (
 // CredentialService handles operations on credentials on SecretHub.
 type CredentialService interface {
 	// Create a new credential from the credentials.Creator for an existing account.
-	Create(string, credentials.Creator) error
+	Create(credentials.Creator, string) error
 	// Disable an existing credential.
 	Disable(fingerprint string) error
 }
@@ -25,7 +25,8 @@ type credentialService struct {
 
 // Create a new credential from the credentials.Creator for an existing account.
 // This includes a re-encrypted copy the the account key.
-func (s credentialService) Create(name string, creator credentials.Creator) error {
+// Description is optional and can be left empty.
+func (s credentialService) Create(creator credentials.Creator, description string) error {
 	accountKey, err := s.client.getAccountKey()
 	if err != nil {
 		return err
@@ -47,10 +48,15 @@ func (s credentialService) Create(name string, creator credentials.Creator) erro
 		return err
 	}
 
+	var reqDescription *string
+	if description != "" {
+		reqDescription = &description
+	}
+
 	req := api.CreateCredentialRequest{
-		Name:        name,
 		Fingerprint: fingerprint,
 		Verifier:    bytes,
+		Description: reqDescription,
 		Type:        verifier.Type(),
 		Metadata:    creator.Metadata(),
 		AccountKey:  accountKeyRequest,


### PR DESCRIPTION
For now we're not setting the credential name on a signup, as this is a backwards-incompatible change. We can later add the functionality to rename any credentials without a name.