### PR TITLE
Verify client version is set correctly on release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  test:
     docker:
       - image: circleci/golang:1.12
     steps:
@@ -14,3 +14,27 @@ jobs:
           paths:
             - /go/pkg/mod
       - run: make test
+  verify-version:
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-modules-{{ checksum "go.mod" }}
+      - run: go mod download
+      - save_cache:
+          key: go-modules-{{ checksum "go.mod" }}
+          paths:
+            - /go/pkg/mod
+      - run: make check-version
+workflows:
+  version: 2
+  pipeline:
+    jobs:
+      - test
+      - verify-version:
+          filters:
+            branches:
+              only:
+                - /release/v[0-9]*\.[0-9]*\.[0-9]*/

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ format-tools:
 
 lint-tools:
 	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+
+check-version:
+	./scripts/check-version/check-version.sh

--- a/scripts/check-version/check-version.sh
+++ b/scripts/check-version/check-version.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+RELEASE_PREFIX="release/"
+
+if [[ $BRANCH == ${RELEASE_PREFIX}* ]]
+then
+  VERSION=${BRANCH#"$RELEASE_PREFIX"}
+  go run ./scripts/check-version/main.go "${VERSION}"
+else
+  echo "Not on a release branch, skipping version check."
+fi

--- a/scripts/check-version/main.go
+++ b/scripts/check-version/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/secrethub/secrethub-go/pkg/secrethub"
+)
+
+func main() {
+	expected := os.Args[1]
+	actual := secrethub.ClientVersion
+
+	if actual != expected {
+		fmt.Fprintf(os.Stderr, "version not as expected: expected %s got %s\n", expected, actual)
+		os.Exit(1)
+	} else {
+		fmt.Println("version as expected")
+	}
+}


### PR DESCRIPTION
To prevent [this](https://github.com/secrethub/secrethub-go/blob/v0.24.0/pkg/secrethub/client_version.go#L5)