### PR TITLE
Trim all v prefixes in user agent

### DIFF
--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -17,8 +17,8 @@ import (
 	"github.com/secrethub/secrethub-go/pkg/secrethub/internals/http"
 )
 
-const (
-	userAgentPrefix = "SecretHub/v1 secrethub-go/" + ClientVersion
+var (
+	userAgentPrefix = "SecretHub/1.0 secrethub-go/" + strings.TrimPrefix(ClientVersion, "v")
 )
 
 // Errors
@@ -86,7 +86,7 @@ type AppInfo struct {
 func (i AppInfo) userAgentSuffix() string {
 	res := i.Name
 	if i.Version != "" {
-		res += "/" + i.Version
+		res += "/" + strings.TrimPrefix(i.Version, "v")
 	}
 	return res
 }


### PR DESCRIPTION
As is conventional for user agents. Instead of 

```
SecretHub/v1 secrethub-go/v0.26.0 secrethub-cli/0.34.0
```
This would result in
```
SecretHub/1.0 secrethub-go/0.26.0 secrethub-cli/0.34.0
```