### PR TITLE
Update secret not found error message

### DIFF
--- a/internals/api/server_errors.go
+++ b/internals/api/server_errors.go
@@ -104,9 +104,14 @@ var (
 
 // IsErrNotFound returns whether the given error is caused by a un-existing resource.
 func IsErrNotFound(err error) bool {
-	statusError, ok := err.(errio.PublicStatusError)
+	publicError, ok := err.(errio.PublicError)
+	if ok {
+		return publicError.Namespace == errio.Namespace("client") && publicError.Code == "secret_not_found"
+	}
+
+	publicStatusError, ok := err.(errio.PublicStatusError)
 	if !ok {
 		return false
 	}
-	return statusError.StatusCode == 404
+	return publicStatusError.StatusCode == 404
 }

--- a/internals/api/server_errors.go
+++ b/internals/api/server_errors.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"fmt"
@@ -104,12 +105,8 @@ var (
 
 // IsErrNotFound returns whether the given error is caused by a un-existing resource.
 func IsErrNotFound(err error) bool {
-	publicError, ok := err.(errio.PublicError)
-	if ok {
-		return publicError.Namespace == errio.Namespace("client") && publicError.Code == "secret_not_found"
-	}
-
-	publicStatusError, ok := err.(errio.PublicStatusError)
+	var publicStatusError errio.PublicStatusError
+	ok := errors.As(err, &publicStatusError)
 	if !ok {
 		return false
 	}

--- a/pkg/secrethub/secret_version.go
+++ b/pkg/secrethub/secret_version.go
@@ -2,6 +2,7 @@ package secrethub
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/secrethub/secrethub-go/pkg/secrethub/iterator"
 
@@ -21,7 +22,7 @@ var (
 	ErrSecretTooBig         = errClient.Code("secret_too_big").Error(fmt.Sprintf("maximum size of a secret is %s", units.BytesSize(MaxSecretSize)))
 	ErrEmptySecret          = errClient.Code("empty_secret").Error("secret is empty")
 	ErrCannotWriteToVersion = errClient.Code("cannot_write_version").Error("cannot (over)write a specific secret version, they are append only")
-	ErrSecretNotFound       = errClient.Code("secret_not_found").ErrorPref("cannot find secret: %s, error: %v")
+	ErrSecretNotFound       = errClient.Code("secret_not_found").StatusErrorPref("cannot find secret: %s, error: %v", http.StatusNotFound)
 )
 
 // SecretVersionService handles operations on secret versions from SecretHub.

--- a/pkg/secrethub/secret_version.go
+++ b/pkg/secrethub/secret_version.go
@@ -24,7 +24,7 @@ var (
 
 type errSecretNotFound struct {
 	path api.SecretPath
-	err error
+	err  error
 }
 
 func (e *errSecretNotFound) Error() string {

--- a/pkg/secrethub/secret_version.go
+++ b/pkg/secrethub/secret_version.go
@@ -110,7 +110,7 @@ func (s secretVersionService) get(path api.SecretPath, withData bool) (*api.Secr
 
 	encVersion, err := s.client.httpClient.GetSecretVersion(blindName, versionParam, withData)
 	if api.IsErrNotFound(err) {
-		return nil, &errSecretNotFound{path:path, err:err}
+		return nil, &errSecretNotFound{path: path, err: err}
 	} else if err != nil {
 		return nil, errio.Error(err)
 	}

--- a/pkg/secrethub/secret_version.go
+++ b/pkg/secrethub/secret_version.go
@@ -93,7 +93,7 @@ func (s secretVersionService) Delete(path string) error {
 func (s secretVersionService) get(path api.SecretPath, withData bool) (*api.SecretVersion, error) {
 	blindName, err := s.client.convertPathToBlindName(path)
 	if api.IsErrNotFound(err) {
-		return nil, &errSecretNotFound{path:path, err:err}
+		return nil, &errSecretNotFound{path: path, err: err}
 	} else if err != nil {
 		return nil, errio.Error(err)
 	}


### PR DESCRIPTION
The `secret not found` error will now include the path of the secret. For example:
```
Encountered an error: cannot find secret: test/test/test, encountered error: Repo not found (server.repo_not_found)  (client.secret_not_found)
```