### PR TITLE
Use + instead of fmt.Sprintf for simple string concatenation

### DIFF
--- a/internals/api/credential.go
+++ b/internals/api/credential.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -251,8 +250,7 @@ func GetFingerprint(t CredentialType, verifier []byte) string {
 		toHash = verifier
 	} else {
 		encodedVerifier := base64.RawStdEncoding.EncodeToString(verifier)
-		toHash = []byte(fmt.Sprintf("credential_type=%s;verifier=%s", t, encodedVerifier))
-
+		toHash = []byte("credential_type=" + string(t) + ";verifier=" + encodedVerifier)
 	}
 	return hex.EncodeToString(crypto.SHA256(toHash))
 }

--- a/internals/api/paths.go
+++ b/internals/api/paths.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"encoding/base64"
-	"fmt"
+	"strconv"
 	"strings"
 
 	"bitbucket.org/zombiezen/cardcpx/natsort"
@@ -155,7 +155,7 @@ func (sp SecretPath) AddVersion(version int) (SecretPath, error) {
 		return SecretPath(""), ErrPathAlreadyHasVersion
 	}
 
-	p := SecretPath(fmt.Sprintf("%s:%d", sp.String(), version))
+	p := SecretPath(sp.String() +":"+ strconv.Itoa(version))
 	err := p.Validate()
 	if err != nil {
 		return SecretPath(""), err
@@ -524,7 +524,7 @@ func blindName(key *crypto.SymmetricKey, path string) (string, error) {
 }
 
 func joinPath(path, name string) string {
-	return fmt.Sprintf("%s%s%s", path, pathSeparator, name)
+	return path + pathSeparator + name
 }
 
 // OrgName

--- a/internals/api/repo.go
+++ b/internals/api/repo.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -40,7 +39,7 @@ type Repo struct {
 
 // Path returns the full repository path.
 func (r Repo) Path() RepoPath {
-	return RepoPath(fmt.Sprintf("%s/%s", r.Owner, r.Name))
+	return RepoPath(r.Owner + "/" + r.Name)
 }
 
 // Trim removes all non-essential fields from Repo for output

--- a/internals/api/secret_version.go
+++ b/internals/api/secret_version.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -28,7 +27,7 @@ const (
 
 // Errors
 var (
-	ErrEncryptedDataTooBig = errAPI.Code("encrypted_data_too_big").Error(fmt.Sprintf("maximum size of encrypted data is %s", units.BytesSize(MaxEncryptedSecretSize)))
+	ErrEncryptedDataTooBig = errAPI.Code("encrypted_data_too_big").Error("maximum size of encrypted data is " + units.BytesSize(MaxEncryptedSecretSize))
 )
 
 // EncryptedSecretVersion represents a version of an encrypted Secret.
@@ -100,7 +99,7 @@ func (sv *SecretVersion) Name() string {
 	if sv.Secret == nil {
 		return strconv.Itoa(sv.Version)
 	}
-	return fmt.Sprintf("%s:%d", sv.Secret.Name, sv.Version)
+	return sv.Secret.Name + ":" + strconv.Itoa(sv.Version)
 }
 
 // ToAuditSubject converts an EncryptedSecret to an AuditSubject

--- a/internals/api/server_errors.go
+++ b/internals/api/server_errors.go
@@ -3,8 +3,6 @@ package api
 import (
 	"net/http"
 
-	"fmt"
-
 	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
@@ -56,8 +54,8 @@ var (
 	ErrSecretKeyNotFound     = errHub.Code("secret_key_not_found").StatusError("Key for secret not found", http.StatusNotFound)
 
 	// Secret Keys
-	ErrSecretKeyFlagged = errAPI.Code("secret_key_flagged").StatusError(fmt.Sprintf("Cannot write new secrets with a key that has status %s", StatusFlagged), http.StatusBadRequest)
-	ErrNoOKSecretKey    = errAPI.Code("no_secret_key_found_with_status_ok").StatusError(fmt.Sprintf("No secret key found with status %s", StatusOK), http.StatusNotFound)
+	ErrSecretKeyFlagged = errAPI.Code("secret_key_flagged").StatusError("Cannot write new secrets with a key that has status "+StatusFlagged, http.StatusBadRequest)
+	ErrNoOKSecretKey    = errAPI.Code("no_secret_key_found_with_status_ok").StatusError("No secret key found with status "+StatusOK, http.StatusNotFound)
 
 	// Organization
 	ErrOrgAlreadyExists         = errAPI.Code("org_already_exists").StatusError("Organization already exists, please create a different organization", http.StatusConflict)

--- a/internals/api/service.go
+++ b/internals/api/service.go
@@ -1,8 +1,8 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/secrethub/secrethub-go/internals/api/uuid"
@@ -15,10 +15,7 @@ var (
 		http.StatusBadRequest,
 	)
 	ErrInvalidServiceDescription = errAPI.Code("invalid_service_description").StatusError(
-		fmt.Sprintf(
-			"service descriptions can at most be %d long and cannot contain any newlines or tabs",
-			serviceDescriptionMaxLength,
-		),
+		"service descriptions can at most be "+strconv.Itoa(serviceDescriptionMaxLength)+" long and cannot contain any newlines or tabs",
 		http.StatusBadRequest,
 	)
 	ErrAccessDeniedToKMSKey = errAPI.Code("access_denied").StatusError("access to KMS key is denied", http.StatusForbidden)

--- a/internals/api/user.go
+++ b/internals/api/user.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"time"
 
 	"net/http"
@@ -55,7 +54,7 @@ func (u User) PrettyName() string {
 	if u.FullName == "" {
 		return u.Username
 	}
-	return fmt.Sprintf("%s (%s)", u.Username, u.FullName)
+	return u.Username + "(" + u.FullName + ")"
 }
 
 // Trim removes all non-essential fields from User for output

--- a/internals/api/user_test.go
+++ b/internals/api/user_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -94,7 +93,7 @@ func TestCreateUserRequest_ValidateUsername_DisallowedCharacters(t *testing.T) {
 	baseName := "user1"
 
 	for _, c := range disallowedCharacters {
-		username := fmt.Sprintf("%s%s", baseName, string(c))
+		username := baseName + string(c)
 
 		err := ValidateUsername(username)
 		if err != ErrInvalidUsername {

--- a/internals/auth/signature.go
+++ b/internals/auth/signature.go
@@ -160,7 +160,7 @@ func (s httpSigner) Authenticate(r *http.Request) error {
 func getMessage(r *http.Request) ([]byte, error) {
 	var result bytes.Buffer
 	// Method \n
-	result.WriteString(fmt.Sprintf("%s\n", r.Method))
+	result.WriteString(r.Method + "\n")
 	// Content-Hash
 	if r.ContentLength == 0 {
 		// Empty body
@@ -177,7 +177,7 @@ func getMessage(r *http.Request) ([]byte, error) {
 		sum := sha256.Sum256(body)
 		encoded := base64.StdEncoding.EncodeToString(sum[:])
 
-		result.WriteString(fmt.Sprintf("%s\n", encoded))
+		result.WriteString(encoded + "\n")
 	}
 	// Date \n
 	requestTime, err := time.Parse(time.RFC1123, r.Header.Get("Date"))
@@ -186,7 +186,7 @@ func getMessage(r *http.Request) ([]byte, error) {
 	}
 	result.WriteString(fmt.Sprintf("%s\n", requestTime))
 	// Resource \n
-	result.WriteString(fmt.Sprintf("%s;", r.URL.Path))
+	result.WriteString(r.URL.Path + ";")
 
 	return result.Bytes(), nil
 }

--- a/internals/aws/service_creator_test.go
+++ b/internals/aws/service_creator_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/secrethub/secrethub-go/internals/api"
@@ -139,7 +138,7 @@ func TestServiceCreator_Wrap(t *testing.T) {
 
 func Test_parseRole(t *testing.T) {
 	defaultAccountID := "1234567890"
-	defaultARN := fmt.Sprintf("arn:aws:iam::%s:role/RoleName", defaultAccountID)
+	defaultARN := "arn:aws:iam::" + defaultAccountID + ":role/RoleName"
 
 	cases := map[string]struct {
 		role      string

--- a/internals/crypto/ciphertext.go
+++ b/internals/crypto/ciphertext.go
@@ -116,7 +116,7 @@ func newEncodedCiphertextMetadata(metadata map[string]string) encodedCiphertextM
 		if len(res) > 0 {
 			separator = ","
 		}
-		res = fmt.Sprintf("%s%s%s=%s", res, separator, k, metadata[k])
+		res = res + separator + k + "=" + metadata[k]
 	}
 
 	return encodedCiphertextMetadata(res)

--- a/internals/crypto/rsa.go
+++ b/internals/crypto/rsa.go
@@ -11,8 +11,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
-	"fmt"
-
 	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
@@ -367,7 +365,7 @@ func (ct CiphertextRSAAES) EncodeToString() string {
 		"key":   base64.StdEncoding.EncodeToString(ct.RSA.Data),
 	})
 
-	return fmt.Sprintf("%s$%s$%s", algorithmRSAAES, data, metadata)
+	return string(algorithmRSAAES) + "$" + data + "$" + string(metadata)
 }
 
 // MarshalJSON encodes the ciphertext in JSON.
@@ -451,7 +449,7 @@ type CiphertextRSA struct {
 // EncodeToString encodes the ciphertext in a string.
 func (ct CiphertextRSA) EncodeToString() string {
 	encodedKey := base64.StdEncoding.EncodeToString(ct.Data)
-	return fmt.Sprintf("%s$%s$", algorithmRSA, encodedKey)
+	return string(algorithmRSA) + "$" + encodedKey + "$"
 }
 
 // MarshalJSON encodes the ciphertext in JSON.

--- a/internals/crypto/symmetric.go
+++ b/internals/crypto/symmetric.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"crypto/hmac"
@@ -151,7 +150,7 @@ func (ct CiphertextAES) EncodeToString() string {
 		"nonce": base64.StdEncoding.EncodeToString(ct.Nonce),
 	})
 
-	return fmt.Sprintf("%s$%s$%s", algorithmAES, data, metadata)
+	return string(algorithmAES) + "$" + data + "$" + string(metadata)
 }
 
 // MarshalJSON encodes the ciphertext in JSON.

--- a/internals/errio/errors.go
+++ b/internals/errio/errors.go
@@ -196,9 +196,9 @@ type PublicError struct {
 func (e PublicError) Error() string {
 	code := e.Code
 	if e.Namespace != "" {
-		code = fmt.Sprintf("%s.%s", e.Namespace, e.Code)
+		code = string(e.Namespace) + "." + e.Code
 	}
-	return fmt.Sprintf("%s (%s) ", e.Message, code)
+	return e.Message + "(" + code + ")"
 }
 
 // Append appends multiple errors to an PublicError.
@@ -206,7 +206,7 @@ func (e PublicError) Append(errs ...error) PublicError {
 	message := e.Message
 
 	for _, err := range errs {
-		message = fmt.Sprintf("%s: %s", err.Error(), message)
+		message = err.Error() + ": " + message
 	}
 
 	return PublicError{
@@ -218,7 +218,7 @@ func (e PublicError) Append(errs ...error) PublicError {
 
 // Type returns the type of the error as to be reported to Sentry.
 func (e PublicError) Type() string {
-	return fmt.Sprintf("%s.%s", e.Namespace, e.Code)
+	return string(e.Namespace) + "." + e.Code
 }
 
 // PublicStatusError represents an http error. It contains an HTTP status
@@ -243,13 +243,13 @@ func (e PublicStatusError) Append(errs ...error) PublicStatusError {
 
 // Type returns the type of the error as to be reported to Sentry.
 func (e PublicStatusError) Type() string {
-	return fmt.Sprintf("%s.%s", e.Namespace, e.Code)
+	return string(e.Namespace) + "." + e.Code
 }
 
 // Wrap wraps multiple errors with a PublicStatusError.
 func Wrap(base PublicStatusError, errs ...error) PublicStatusError {
 	for _, err := range errs {
-		base.Message = fmt.Sprintf("%s: %s", base.Message, err.Error())
+		base.Message = base.Message + ": " + err.Error()
 	}
 
 	return base

--- a/pkg/secrethub/internals/http/client.go
+++ b/pkg/secrethub/internals/http/client.go
@@ -291,7 +291,7 @@ func (c *Client) AuditRepoPaginator(namespace, repoName string) *AuditPaginator 
 }
 
 func (c *Client) auditRepoURL(namespace, repoName string) url.URL {
-	return joinURL(c.base, fmt.Sprintf("/namespaces/%s/repos/%s/events", namespace, repoName))
+	return joinURL(c.base, "/namespaces/"+namespace+"/repos/"+repoName+"/events")
 }
 
 func newAuditPaginator(requestURL url.URL, client *Client) *AuditPaginator {
@@ -589,7 +589,7 @@ func (c *Client) AuditSecretPaginator(secretBlindName string) *AuditPaginator {
 }
 
 func (c *Client) auditSecretURL(secretBlindName string) url.URL {
-	return joinURL(c.base, fmt.Sprintf("/secrets/%s/events", secretBlindName))
+	return joinURL(c.base, "/secrets/"+secretBlindName+"/events")
 }
 
 // DeleteSecret deletes a secret.

--- a/pkg/secrethub/secret_version.go
+++ b/pkg/secrethub/secret_version.go
@@ -1,8 +1,6 @@
 package secrethub
 
 import (
-	"fmt"
-
 	"github.com/secrethub/secrethub-go/pkg/secrethub/iterator"
 
 	units "github.com/docker/go-units"
@@ -18,7 +16,7 @@ const (
 
 // Errors
 var (
-	ErrSecretTooBig         = errClient.Code("secret_too_big").Error(fmt.Sprintf("maximum size of a secret is %s", units.BytesSize(MaxSecretSize)))
+	ErrSecretTooBig         = errClient.Code("secret_too_big").Error("maximum size of a secret is " + units.BytesSize(MaxSecretSize))
 	ErrEmptySecret          = errClient.Code("empty_secret").Error("secret is empty")
 	ErrCannotWriteToVersion = errClient.Code("cannot_write_version").Error("cannot (over)write a specific secret version, they are append only")
 )


### PR DESCRIPTION
Replaced `fmt.Sprintf` with `+` where it does not affect readability.
See also: https://github.com/secrethub/secrethub-go/pull/58#discussion_r263422145