### PR TITLE
Add secret path to all secret not found errors

### DIFF
--- a/pkg/secrethub/secret.go
+++ b/pkg/secrethub/secret.go
@@ -111,12 +111,16 @@ func (s secretService) Get(path string) (*api.Secret, error) {
 	}
 
 	blindName, err := s.client.convertPathToBlindName(secretPath)
-	if err != nil {
+	if api.IsErrNotFound(err) {
+		return nil, &errSecretNotFound{path: secretPath, err: err}
+	} else if err != nil {
 		return nil, errio.Error(err)
 	}
 
 	encSecret, err := s.client.httpClient.GetSecret(blindName)
-	if err != nil {
+	if api.IsErrNotFound(err) {
+		return nil, &errSecretNotFound{path: secretPath, err: err}
+	} else if err != nil {
 		return nil, errio.Error(err)
 	}
 

--- a/pkg/secrethub/secret_version.go
+++ b/pkg/secrethub/secret_version.go
@@ -146,12 +146,16 @@ func (s secretVersionService) GetWithoutData(path string) (*api.SecretVersion, e
 
 func (s secretVersionService) list(path api.SecretPath, withData bool) ([]*api.SecretVersion, error) {
 	blindName, err := s.client.convertPathToBlindName(path)
-	if err != nil {
+	if api.IsErrNotFound(err) {
+		return nil, &errSecretNotFound{path: path, err: err}
+	} else if err != nil {
 		return nil, errio.Error(err)
 	}
 
 	versions, err := s.client.httpClient.ListSecretVersions(blindName, withData)
-	if err != nil {
+	if api.IsErrNotFound(err) {
+		return nil, &errSecretNotFound{path: path, err: err}
+	} else if err != nil {
 		return nil, errio.Error(err)
 	}
 


### PR DESCRIPTION
Return `errSecretNotFound` from both `SecretVersionService` when secrets are listed and `SecretService` when get method is called.

The goal of this PR is to make the client always return `errSecretNotFound` when a secret is not found as opposed to a server error (`ErrSecretNotFound`) when listing secret versions and getting secrets and the client error: `errSecretNotFound` when getting secret versions.