### PR TITLE
Make setting app info more extensible

### DIFF
--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -72,7 +72,7 @@ type Client struct {
 	// These are cached
 	repoIndexKeys map[api.RepoPath]*crypto.SymmetricKey
 
-	appInfo   *AppInfo
+	appInfo   []*AppInfo
 	ConfigDir *configdir.Dir
 }
 
@@ -83,7 +83,7 @@ type AppInfo struct {
 	Version string
 }
 
-func (i AppInfo) userAgentSuffix() string {
+func (i AppInfo) userAgentComponent() string {
 	res := i.Name
 	if i.Version != "" {
 		res += "/" + strings.TrimPrefix(i.Version, "v")
@@ -235,8 +235,8 @@ func (c *Client) DefaultCredential() credentials.Reader {
 
 func (c *Client) userAgent() string {
 	userAgent := userAgentPrefix
-	if c.appInfo != nil {
-		userAgent += " " + c.appInfo.userAgentSuffix()
+	for _, info := range c.appInfo {
+		userAgent += " " + info.userAgentComponent()
 	}
 	osName, err := operatingsystem.GetOperatingSystem()
 	if err != nil {

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -54,12 +54,12 @@ type ClientInterface interface {
 var (
 	errClient = errio.Namespace("client")
 
-	whitelistAppInfoName = regexp.MustCompile("^[a-zA-Z0-9_-]*$")
+	whitelistAppInfoName = regexp.MustCompile("^[a-zA-Z0-9_-]{2,64}$")
 )
 
 // Errors
 var (
-	ErrInvalidAppInfoName = errClient.Code("invalid_app_info_name").Error("name must be set and can only contain alphanumeric, underscore (_), and dash (-) characters")
+	ErrInvalidAppInfoName = errClient.Code("invalid_app_info_name").Error("name must be 2-64 characters long, only alphanumeric, underscore (_), and dash (-)")
 )
 
 // Client is a client for the SecretHub HTTP API.
@@ -99,7 +99,7 @@ func (i AppInfo) userAgentComponent() string {
 	return res
 }
 
-// ValidateName returns an error if the provided app name is not set or doesn't match alphanumeric, underscore (_), and dash (-) characters.
+// ValidateName returns an error if the provided app name is not set or doesn't match alphanumeric, underscore (_), and dash (-) characters, or length of 2-64 characters.
 func (i AppInfo) ValidateName() error {
 	if i.Name == "" || !whitelistAppInfoName.MatchString(i.Name) {
 		return ErrInvalidAppInfoName

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -54,12 +54,12 @@ type ClientInterface interface {
 var (
 	errClient = errio.Namespace("client")
 
-	whitelistAppInfoName = regexp.MustCompile("^[a-zA-Z0-9_-]{2,64}$")
+	whitelistAppInfoName = regexp.MustCompile("^[a-zA-Z0-9_-]{2,50}$")
 )
 
 // Errors
 var (
-	ErrInvalidAppInfoName = errClient.Code("invalid_app_info_name").Error("name must be 2-64 characters long, only alphanumeric, underscore (_), and dash (-)")
+	ErrInvalidAppInfoName = errClient.Code("invalid_app_info_name").Error("name must be 2-50 characters long, only alphanumeric, underscore (_), and dash (-)")
 )
 
 // Client is a client for the SecretHub HTTP API.
@@ -99,7 +99,7 @@ func (i AppInfo) userAgentComponent() string {
 	return res
 }
 
-// ValidateName returns an error if the provided app name is not set or doesn't match alphanumeric, underscore (_), and dash (-) characters, or length of 2-64 characters.
+// ValidateName returns an error if the provided app name is not set or doesn't match alphanumeric, underscore (_), and dash (-) characters, or length of 2-50 characters.
 func (i AppInfo) ValidateName() error {
 	if i.Name == "" || !whitelistAppInfoName.MatchString(i.Name) {
 		return ErrInvalidAppInfoName

--- a/pkg/secrethub/client_options.go
+++ b/pkg/secrethub/client_options.go
@@ -1,7 +1,6 @@
 package secrethub
 
 import (
-	"errors"
 	"net/http"
 	"net/url"
 	"time"
@@ -51,8 +50,8 @@ func WithTransport(transport http.RoundTripper) ClientOption {
 // WithAppInfo sets the AppInfo to be used for identifying the application that is using the SecretHub Client.
 func WithAppInfo(appInfo *AppInfo) ClientOption {
 	return func(c *Client) error {
-		if appInfo.Name == "" {
-			return errors.New("name must be set for AppInfo")
+		if err := appInfo.ValidateName(); err != nil {
+			return err
 		}
 		c.appInfo = append(c.appInfo, appInfo)
 		return nil

--- a/pkg/secrethub/client_options.go
+++ b/pkg/secrethub/client_options.go
@@ -54,7 +54,7 @@ func WithAppInfo(appInfo *AppInfo) ClientOption {
 		if appInfo.Name == "" {
 			return errors.New("name must be set for AppInfo")
 		}
-		c.appInfo = appInfo
+		c.appInfo = append(c.appInfo, appInfo)
 		return nil
 	}
 }

--- a/pkg/secrethub/client_test.go
+++ b/pkg/secrethub/client_test.go
@@ -1,0 +1,74 @@
+package secrethub
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/secrethub/secrethub-go/internals/assert"
+)
+
+func TestClient_userAgent(t *testing.T) {
+	cases := map[string]struct {
+		appInfo       []*AppInfo
+		envAppName    string
+		envAppVersion string
+		expected      string
+		err           error
+	}{
+		"default": {},
+		"multiple app info layers": {
+			appInfo: []*AppInfo{
+				{Name: "secrethub-xgo", Version: "0.1.0"},
+				{Name: "secrethub-java", Version: "0.2.0"},
+			},
+			expected: "secrethub-xgo/0.1.0 secrethub-java/0.2.0",
+		},
+		"top level app info from environment": {
+			appInfo: []*AppInfo{
+				{Name: "secrethub-cli", Version: "0.37.0"},
+			},
+			envAppName:    "secrethub-circleci-orb",
+			envAppVersion: "1.0.0",
+			expected:      "secrethub-cli/0.37.0 secrethub-circleci-orb/1.0.0",
+		},
+		"invalid app name": {
+			appInfo: []*AppInfo{
+				{Name: "illegal-name*%!@", Version: "0.1.0"},
+			},
+			err: ErrInvalidAppInfoName,
+		},
+		"ignore faulty environment variable": {
+			appInfo: []*AppInfo{
+				{Name: "secrethub-cli", Version: "0.37.0"},
+			},
+			envAppName: "illegal-name*%!@",
+			expected:   "secrethub-cli/0.37.0",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			os.Setenv("SECRETHUB_APP_INFO_NAME", tc.envAppName)
+			os.Setenv("SECRETHUB_APP_INFO_VERSION", tc.envAppVersion)
+
+			var opts []ClientOption
+			for _, info := range tc.appInfo {
+				opts = append(opts, WithAppInfo(info))
+			}
+			client, err := NewClient(opts...)
+			assert.Equal(t, err, tc.err)
+			if err != nil {
+				return
+			}
+
+			userAgent := client.userAgent()
+			pattern := tc.expected + " \\(.*\\)"
+			matched, err := regexp.MatchString(pattern, userAgent)
+			assert.OK(t, err)
+			if !matched {
+				t.Errorf("user agent '%s' doesn't match pattern '%s'", userAgent, pattern)
+			}
+		})
+	}
+}

--- a/pkg/secrethub/client_test.go
+++ b/pkg/secrethub/client_test.go
@@ -24,6 +24,12 @@ func TestClient_userAgent(t *testing.T) {
 			},
 			expected: "secrethub-xgo/0.1.0 secrethub-java/0.2.0",
 		},
+		"no version number": {
+			appInfo: []*AppInfo{
+				{Name: "terraform-provider-secrethub"},
+			},
+			expected: "terraform-provider-secrethub",
+		},
 		"top level app info from environment": {
 			appInfo: []*AppInfo{
 				{Name: "secrethub-cli", Version: "0.37.0"},


### PR DESCRIPTION
Passing app info to the client is now more extensible, so it can handle:

```
secrethub-go/0.27.0 secrethub-cli/0.37.0 secrethub-circleci-orb/1.0.0
```

Where the third layer comes from `SECRETHUB_APP_INFO_NAME`.

It can now also handle more layers of 'wrapped clients', e.g.: 

```
secrethub-go/0.27.0 secrethub-xgo/0.1.0 secrethub-java/0.2.0 jenkins-secrethub-plugin/1.0.0
```

### Validation
But with greater extensibility, comes greater validation: when using `SECRETHUB_APP_INFO_NAME`, it ignores values if they don't match `[a-zA-Z0-9_-]` and when explicitly setting `WithAppInfo` it actually errors, because as an SDK consumer you'll want to immediately know if (and why) your supplied value didn't come through.

**Note**: there's no validation on the app info _version number_ at the moment, because next to the regular x.y.z versions, there also versions like commit hashes showing up sometimes and it's probably more desirable to have those come through, than have them ignored (or rejected). Agreed? Or should we see if we can find at least some layer of validation there?