### PR TITLE
Create account along with key in one atomic request

### DIFF
--- a/internals/api/credential.go
+++ b/internals/api/credential.go
@@ -162,13 +162,6 @@ func (req *CreateCredentialRequest) Validate() error {
 		}
 	}
 
-	if req.AccountKey == nil {
-		return ErrMissingField("account_key")
-	}
-	if err := req.AccountKey.Validate(); err != nil {
-		return err
-	}
-
 	expectedMetadata, validCredentialType := credentialTypesMetadata[req.Type]
 	if !validCredentialType {
 		return ErrInvalidCredentialType
@@ -188,6 +181,12 @@ func (req *CreateCredentialRequest) Validate() error {
 	for actualMetadataKey := range req.Metadata {
 		if _, ok := expectedMetadata[actualMetadataKey]; !ok {
 			return ErrUnknownMetadataKey(actualMetadataKey)
+		}
+	}
+
+	if req.AccountKey != nil {
+		if err := req.AccountKey.Validate(); err != nil {
+			return err
 		}
 	}
 

--- a/internals/api/credential.go
+++ b/internals/api/credential.go
@@ -162,6 +162,13 @@ func (req *CreateCredentialRequest) Validate() error {
 		}
 	}
 
+	if req.AccountKey == nil {
+		return ErrMissingField("account_key")
+	}
+	if err := req.AccountKey.Validate(); err != nil {
+		return err
+	}
+
 	expectedMetadata, validCredentialType := credentialTypesMetadata[req.Type]
 	if !validCredentialType {
 		return ErrInvalidCredentialType
@@ -181,12 +188,6 @@ func (req *CreateCredentialRequest) Validate() error {
 	for actualMetadataKey := range req.Metadata {
 		if _, ok := expectedMetadata[actualMetadataKey]; !ok {
 			return ErrUnknownMetadataKey(actualMetadataKey)
-		}
-	}
-
-	if req.AccountKey != nil {
-		if err := req.AccountKey.Validate(); err != nil {
-			return err
 		}
 	}
 

--- a/internals/api/service.go
+++ b/internals/api/service.go
@@ -82,6 +82,13 @@ func (req CreateServiceRequest) Validate() error {
 		return err
 	}
 
+	if req.Credential.AccountKey == nil{
+		return ErrMissingField("account_key")
+	}
+	if err := req.Credential.AccountKey.Validate(); err != nil {
+		return err
+	}
+
 	if req.RepoMember == nil {
 		return ErrMissingField("repo_member")
 	}

--- a/internals/api/service.go
+++ b/internals/api/service.go
@@ -66,7 +66,6 @@ func (a Service) ToAuditActor() *AuditActor {
 type CreateServiceRequest struct {
 	Description string                   `json:"description"`
 	Credential  *CreateCredentialRequest `json:"credential"`
-	AccountKey  *CreateAccountKeyRequest `json:"account_key"`
 	RepoMember  *CreateRepoMemberRequest `json:"repo_member"`
 }
 
@@ -80,13 +79,6 @@ func (req CreateServiceRequest) Validate() error {
 		return ErrMissingField("credential")
 	}
 	if err := req.Credential.Validate(); err != nil {
-		return err
-	}
-
-	if req.AccountKey == nil {
-		return ErrMissingField("account_key")
-	}
-	if err := req.AccountKey.Validate(); err != nil {
 		return err
 	}
 

--- a/internals/api/service.go
+++ b/internals/api/service.go
@@ -82,7 +82,7 @@ func (req CreateServiceRequest) Validate() error {
 		return err
 	}
 
-	if req.Credential.AccountKey == nil{
+	if req.Credential.AccountKey == nil {
 		return ErrMissingField("account_key")
 	}
 	if err := req.Credential.AccountKey.Validate(); err != nil {

--- a/pkg/secrethub/account.go
+++ b/pkg/secrethub/account.go
@@ -71,10 +71,15 @@ func (c *Client) createAccountKeyRequest(encrypter credentials.Encrypter, accoun
 	}, nil
 }
 
-func (c *Client) createCredentialRequest(verifier credentials.Verifier, metadata map[string]string) (*api.CreateCredentialRequest, error) {
+func (c *Client) createCredentialRequest(encrypter credentials.Encrypter, accountKey crypto.RSAPrivateKey, verifier credentials.Verifier, metadata map[string]string) (*api.CreateCredentialRequest, error) {
 	bytes, fingerprint, err := verifier.Export()
 	if err != nil {
 		return nil, errio.Error(err)
+	}
+
+	accountKeyReq, err := c.createAccountKeyRequest(encrypter, accountKey)
+	if err != nil {
+		return nil, err
 	}
 
 	req := api.CreateCredentialRequest{
@@ -82,6 +87,7 @@ func (c *Client) createCredentialRequest(verifier credentials.Verifier, metadata
 		Verifier:    bytes,
 		Type:        verifier.Type(),
 		Metadata:    metadata,
+		AccountKey:  accountKeyReq,
 	}
 	err = verifier.AddProof(&req)
 	if err != nil {

--- a/pkg/secrethub/service.go
+++ b/pkg/secrethub/service.go
@@ -67,7 +67,6 @@ func (s serviceService) Create(path string, description string, credentialCreato
 	in := &api.CreateServiceRequest{
 		Description: description,
 		Credential:  credentialRequest,
-		AccountKey:  credentialRequest.AccountKey,
 		RepoMember:  serviceRepoMemberRequest,
 	}
 

--- a/pkg/secrethub/service.go
+++ b/pkg/secrethub/service.go
@@ -54,17 +54,12 @@ func (s serviceService) Create(path string, description string, credentialCreato
 		return nil, errio.Error(err)
 	}
 
-	credentialRequest, err := s.client.createCredentialRequest(credentialCreator.Verifier(), credentialCreator.Metadata())
+	credentialRequest, err := s.client.createCredentialRequest(credentialCreator.Encrypter(), accountKey, credentialCreator.Verifier(), credentialCreator.Metadata())
 	if err != nil {
 		return nil, errio.Error(err)
 	}
 
-	accountKeyRequest, err := s.client.createAccountKeyRequest(credentialCreator.Encrypter(), accountKey)
-	if err != nil {
-		return nil, errio.Error(err)
-	}
-
-	serviceRepoMemberRequest, err := s.client.createRepoMemberRequest(repoPath, accountKeyRequest.PublicKey)
+	serviceRepoMemberRequest, err := s.client.createRepoMemberRequest(repoPath, credentialRequest.AccountKey.PublicKey)
 	if err != nil {
 		return nil, errio.Error(err)
 	}
@@ -72,7 +67,7 @@ func (s serviceService) Create(path string, description string, credentialCreato
 	in := &api.CreateServiceRequest{
 		Description: description,
 		Credential:  credentialRequest,
-		AccountKey:  accountKeyRequest,
+		AccountKey:  credentialRequest.AccountKey,
 		RepoMember:  serviceRepoMemberRequest,
 	}
 

--- a/pkg/secrethub/user.go
+++ b/pkg/secrethub/user.go
@@ -63,7 +63,7 @@ func (s userService) Create(username, email, fullName string, credentials creden
 }
 
 func (s userService) create(username, email, fullName string, accountKey crypto.RSAPrivateKey, verifier credentials.Verifier, encrypter credentials.Encrypter, metadata map[string]string, credentials credentials.Provider) (*api.User, error) {
-	credentialRequest, err := s.client.createCredentialRequest(verifier, metadata)
+	credentialRequest, err := s.client.createCredentialRequest(encrypter, accountKey, verifier, metadata)
 	if err != nil {
 		return nil, errio.Error(err)
 	}
@@ -90,13 +90,6 @@ func (s userService) create(username, email, fullName string, accountKey crypto.
 	if err != nil {
 		return nil, err
 	}
-
-	accountKeyResponse, err := s.client.createAccountKey(credentialRequest.Fingerprint, accountKey, encrypter)
-	if err != nil {
-		return nil, err
-	}
-
-	user.PublicKey = accountKeyResponse.PublicKey
 
 	return user, nil
 }

--- a/pkg/secrethub/user_test.go
+++ b/pkg/secrethub/user_test.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -31,6 +30,12 @@ func TestSignup(t *testing.T) {
 		client: Must(NewClient(opts...)),
 	}
 
+	accountKey, err := crypto.GenerateRSAPrivateKey(512)
+	assert.OK(t, err)
+
+	publicAccountKey, err := accountKey.Public().Encode()
+	assert.OK(t, err)
+
 	expectedCreateUserRequest := api.CreateUserRequest{
 		Username: username,
 		FullName: fullName,
@@ -40,12 +45,17 @@ func TestSignup(t *testing.T) {
 			Fingerprint: cred1Fingerprint,
 			Verifier:    cred1Verifier,
 			Proof:       &api.CredentialProofKey{},
+			AccountKey: &api.CreateAccountKeyRequest{
+				PublicKey: publicAccountKey,
+			},
 		},
 	}
+
 
 	now := time.Now().UTC()
 	expectedResponse := &api.User{
 		AccountID:   uuid.New(),
+		PublicKey:   publicAccountKey,
 		Username:    username,
 		FullName:    fullName,
 		Email:       email,
@@ -60,30 +70,9 @@ func TestSignup(t *testing.T) {
 
 		assert.OK(t, req.Validate())
 
-		assert.Equal(t, req, expectedCreateUserRequest)
-
-		// Respond
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(expectedResponse)
-	})
-
-	accountKey, err := crypto.GenerateRSAPrivateKey(512)
-	assert.OK(t, err)
-
-	publicAccountKey, err := accountKey.Public().Encode()
-	assert.OK(t, err)
-
-	router.Post(fmt.Sprintf("/me/credentials/%s/key", cred1Fingerprint), func(w http.ResponseWriter, r *http.Request) {
-		// Assert
-		req := new(api.CreateAccountKeyRequest)
-		err := json.NewDecoder(r.Body).Decode(&req)
-		assert.OK(t, err)
-
-		assert.OK(t, req.Validate())
-
 		// We cannot predict the output of the encrypted key, therefore we do not test it here.
-		assert.Equal(t, req.PublicKey, publicAccountKey)
+		req.Credential.AccountKey.EncryptedPrivateKey = nil
+		assert.Equal(t, req, expectedCreateUserRequest)
 
 		// Respond
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/secrethub/user_test.go
+++ b/pkg/secrethub/user_test.go
@@ -51,7 +51,6 @@ func TestSignup(t *testing.T) {
 		},
 	}
 
-
 	now := time.Now().UTC()
 	expectedResponse := &api.User{
 		AccountID:   uuid.New(),


### PR DESCRIPTION
This merge request removes the separate `createAccountKeyRequest` and embeds the account key into the `createCredentialRequest`.
This is done to prevent ending up with unusable accounts if the `createAccountKey` request fails.