### PR TITLE
Fix session expiration check

### DIFF
--- a/pkg/secrethub/credentials/sessions/session.go
+++ b/pkg/secrethub/credentials/sessions/session.go
@@ -38,5 +38,5 @@ type expireTime time.Time
 
 // NeedsRefresh returns true when the session is about to expire and should be refreshed.
 func (t expireTime) NeedsRefresh() bool {
-	return time.Time(t).After(time.Now().Add(expirationMargin))
+	return time.Now().After(time.Time(t).Add(-expirationMargin))
 }

--- a/pkg/secrethub/credentials/sessions/session_test.go
+++ b/pkg/secrethub/credentials/sessions/session_test.go
@@ -1,0 +1,34 @@
+package sessions
+
+import (
+	"testing"
+	"time"
+
+	"github.com/secrethub/secrethub-go/internals/assert"
+)
+
+func TestExpireTimeNeedsRefresh(t *testing.T) {
+	cases := map[string]struct {
+		in       time.Time
+		expected bool
+	}{
+		"not expired": {
+			in:       time.Now().Add(time.Minute),
+			expected: false,
+		},
+		"in margin": {
+			in:       time.Now().Add(time.Second * 10),
+			expected: true,
+		},
+		"past": {
+			in:       time.Now().Add(-time.Second * 10),
+			expected: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, expireTime(tc.in).NeedsRefresh(), tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
The previous check always returned true if the check was performed before the expiration. In most cases this did not hindered the actual functionality of the sessions because the session was just always refreshed. However, if a session was used after it was expired, the client wrongly assumed that the session was still valid, which led to a server error.