### PR TITLE
Add a message to GCP errors without a message

### DIFF
--- a/internals/gcp/errors.go
+++ b/internals/gcp/errors.go
@@ -28,17 +28,17 @@ func HandleError(err error) error {
 		switch errGCP.Code {
 		case http.StatusNotFound:
 			if message == "" {
-				message = "404 not found"
+				message = "Response from the Google API: 404 Not Found"
 			}
 			return ErrGCPNotFound.Error(message)
 		case http.StatusForbidden:
 			if message == "" {
-				message = "403 access denied"
+				message = "Response from the Google API: 403 Forbidden"
 			}
 			return ErrGCPAccessDenied.Error(message)
 		case http.StatusConflict:
 			if message == "" {
-				message = "409 conflict"
+				message = "Response from the Google API: 409 Conflict"
 			}
 			return ErrGCPAlreadyExists.Error(message)
 		}

--- a/internals/gcp/errors.go
+++ b/internals/gcp/errors.go
@@ -24,13 +24,23 @@ var (
 func HandleError(err error) error {
 	errGCP, ok := err.(*googleapi.Error)
 	if ok {
+		message := errGCP.Message
 		switch errGCP.Code {
 		case http.StatusNotFound:
-			return ErrGCPNotFound.Error(errGCP.Message)
+			if message == "" {
+				message = "404 not found"
+			}
+			return ErrGCPNotFound.Error(message)
 		case http.StatusForbidden:
-			return ErrGCPAccessDenied.Error(errGCP.Message)
+			if message == "" {
+				message = "403 access denied"
+			}
+			return ErrGCPAccessDenied.Error(message)
 		case http.StatusConflict:
-			return ErrGCPAlreadyExists.Error(errGCP.Message)
+			if message == "" {
+				message = "409 conflict"
+			}
+			return ErrGCPAlreadyExists.Error(message)
 		}
 		if len(errGCP.Errors) > 0 {
 			return gcpErr.Code(errGCP.Errors[0].Reason).Error(errGCP.Errors[0].Message)


### PR DESCRIPTION
Before https://github.com/secrethub/secrethub-cli/pull/312 the not found error without a message was returned to the user on invalid keyring: `Encountered an error:  (gcp.not_found) `. We should aim never to return these vague errors to the user, but just to be on the safe side for when they do occur, having an actual error message to show would be nice.