### PR TITLE
Add iterators for idplink and credentials

### DIFF
--- a/pkg/secrethub/fakeclient/credentials.go
+++ b/pkg/secrethub/fakeclient/credentials.go
@@ -4,6 +4,7 @@ import (
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
+	"github.com/secrethub/secrethub-go/pkg/secrethub/iterator"
 )
 
 type CredentialService struct {
@@ -22,4 +23,23 @@ func (c *CredentialService) Disable(fingerprint string) error {
 
 func (c *CredentialService) List(credentialListParams *secrethub.CredentialListParams) secrethub.CredentialIterator {
 	return c.ListFunc(credentialListParams)
+}
+
+type CredentialIterator struct {
+	Credentials  []*api.Credential
+	CurrentIndex int
+	Err          error
+}
+
+func (c *CredentialIterator) Next() (api.Credential, error) {
+	if c.Err != nil {
+		return api.Credential{}, c.Err
+	}
+
+	currentIndex := c.CurrentIndex
+	if currentIndex >= len(c.Credentials) {
+		return api.Credential{}, iterator.Done
+	}
+	c.CurrentIndex++
+	return *c.Credentials[currentIndex], nil
 }

--- a/pkg/secrethub/fakeclient/idp_link.go
+++ b/pkg/secrethub/fakeclient/idp_link.go
@@ -4,6 +4,7 @@ import (
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/oauthorizer"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
+	"github.com/secrethub/secrethub-go/pkg/secrethub/iterator"
 )
 
 type IDPLinkService struct {
@@ -45,4 +46,23 @@ func (i IDPLinkGCPService) Delete(namespace string, projectID string) error {
 
 func (i IDPLinkGCPService) AuthorizationCodeListener(namespace string, projectID string) (oauthorizer.CallbackHandler, error) {
 	return i.AuthorizationCodeListenerFunc(namespace, projectID)
+}
+
+type IDPLinkIterator struct {
+	IDPLinks     []*api.IdentityProviderLink
+	CurrentIndex int
+	Err          error
+}
+
+func (c *IDPLinkIterator) Next() (api.IdentityProviderLink, error) {
+	if c.Err != nil {
+		return api.IdentityProviderLink{}, c.Err
+	}
+
+	currentIndex := c.CurrentIndex
+	if currentIndex >= len(c.IDPLinks) {
+		return api.IdentityProviderLink{}, iterator.Done
+	}
+	c.CurrentIndex++
+	return *c.IDPLinks[currentIndex], nil
 }


### PR DESCRIPTION
In fakeclient, both credentials and IDPLink have a function `List` that returns an iterator. However, currently, the user cannot mock the iterator itself.
Therefore, this PR enables the user to mock these to make testing of these functions smoother.

This PR tackles the following PR from the CLI: https://github.com/secrethub/secrethub-cli/pull/329