### PR TITLE
Allow acount key creation with setup code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	google.golang.org/api v0.26.0
 	google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940
+	google.golang.org/grpc v1.28.0
 )
 
 go 1.13

--- a/internals/api/patterns.go
+++ b/internals/api/patterns.go
@@ -39,6 +39,7 @@ var (
 	whitelistOrgName            = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s{%d,%d})$`, patternUniformNameCharacters, uniformNameMinimumLength, uniformNameMaximumLength))
 	whitelistFullName           = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s{1,128})$`, patternFullName))
 	whitelistDescription        = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s)$`, patternDescription))
+	whitelistSetupCode = regexp.MustCompile("su-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}")
 
 	whitelistAtLeastOneAlphanumeric = regexp.MustCompile(fmt.Sprintf("%s{1,}", patternAlphanumeric))
 
@@ -89,6 +90,7 @@ var (
 	ErrInvalidGCPServiceAccountEmail        = errAPI.Code("invalid_service_account_email").StatusError("not a valid GCP service account email", http.StatusBadRequest)
 	ErrNotUserManagerGCPServiceAccountEmail = errAPI.Code("require_user_managed_service_account").StatusError("provided GCP service account email is not for a user-manager service account", http.StatusBadRequest)
 	ErrInvalidGCPKMSResourceID              = errAPI.Code("invalid_key_resource_id").StatusError("not a valid resource ID, expected: projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY", http.StatusBadRequest)
+	ErrInvalidSetupCode = errAPI.Code("invalid_setup_code").StatusError("setup codes consist of the su- prefix followed by 4 groups of lowercase alphanumeric strings separated by dashes", http.StatusBadRequest, )
 )
 
 // ValidateNamespace validates a username.
@@ -351,5 +353,13 @@ func ValidateGCPKMSKeyResourceID(v string) error {
 		return ErrInvalidGCPKMSResourceID
 	}
 
+	return nil
+}
+
+// ValidateSetupCode checks whether the given string has the format of a valid setup code.
+func ValidateSetupCode(code string) error {
+	if !whitelistSetupCode.MatchString(code) {
+		return ErrInvalidSetupCode
+	}
 	return nil
 }

--- a/internals/api/patterns.go
+++ b/internals/api/patterns.go
@@ -39,7 +39,7 @@ var (
 	whitelistOrgName            = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s{%d,%d})$`, patternUniformNameCharacters, uniformNameMinimumLength, uniformNameMaximumLength))
 	whitelistFullName           = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s{1,128})$`, patternFullName))
 	whitelistDescription        = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s)$`, patternDescription))
-	whitelistSetupCode          = regexp.MustCompile("su-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}")
+	whitelistSetupCode          = regexp.MustCompile("^su-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$")
 
 	whitelistAtLeastOneAlphanumeric = regexp.MustCompile(fmt.Sprintf("%s{1,}", patternAlphanumeric))
 

--- a/internals/api/patterns.go
+++ b/internals/api/patterns.go
@@ -39,7 +39,7 @@ var (
 	whitelistOrgName            = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s{%d,%d})$`, patternUniformNameCharacters, uniformNameMinimumLength, uniformNameMaximumLength))
 	whitelistFullName           = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s{1,128})$`, patternFullName))
 	whitelistDescription        = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s)$`, patternDescription))
-	whitelistSetupCode = regexp.MustCompile("su-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}")
+	whitelistSetupCode          = regexp.MustCompile("su-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}")
 
 	whitelistAtLeastOneAlphanumeric = regexp.MustCompile(fmt.Sprintf("%s{1,}", patternAlphanumeric))
 
@@ -90,7 +90,7 @@ var (
 	ErrInvalidGCPServiceAccountEmail        = errAPI.Code("invalid_service_account_email").StatusError("not a valid GCP service account email", http.StatusBadRequest)
 	ErrNotUserManagerGCPServiceAccountEmail = errAPI.Code("require_user_managed_service_account").StatusError("provided GCP service account email is not for a user-manager service account", http.StatusBadRequest)
 	ErrInvalidGCPKMSResourceID              = errAPI.Code("invalid_key_resource_id").StatusError("not a valid resource ID, expected: projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY", http.StatusBadRequest)
-	ErrInvalidSetupCode = errAPI.Code("invalid_setup_code").StatusError("setup codes consist of the su- prefix followed by 4 groups of lowercase alphanumeric strings separated by dashes", http.StatusBadRequest, )
+	ErrInvalidSetupCode                     = errAPI.Code("invalid_setup_code").StatusError("setup codes consist of the su- prefix followed by 4 groups of lowercase alphanumeric strings separated by dashes", http.StatusBadRequest)
 )
 
 // ValidateNamespace validates a username.

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -138,7 +138,7 @@ func NewClient(with ...ClientOption) (*Client, error) {
 	}
 
 	// Try to use default key credentials if none provided explicitly
-	if client.decrypter == nil {
+	if !client.httpClient.IsAuthenticated() && client.decrypter == nil {
 		identityProvider := os.Getenv("SECRETHUB_IDENTITY_PROVIDER")
 
 		var provider credentials.Provider

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -207,7 +207,7 @@ func (c *Client) Accounts() AccountService {
 
 // Credentials returns a service used to manage credentials.
 func (c *Client) Credentials() CredentialService {
-	return newCredentialService(c)
+	return newCredentialService(c, c.httpClient.IsAuthenticated, c.isKeyed)
 }
 
 // Dirs returns a service used to manage directories.
@@ -270,6 +270,10 @@ func (c *Client) DefaultCredential() credentials.Reader {
 	}
 
 	return c.ConfigDir.Credential()
+}
+
+func (c *Client) isKeyed() bool {
+	return c.decrypter != nil
 }
 
 func (c *Client) userAgent() string {

--- a/pkg/secrethub/client_options.go
+++ b/pkg/secrethub/client_options.go
@@ -88,6 +88,7 @@ func WithSetupCode(setupCode string) ClientOption {
 		if err != nil {
 			return err
 		}
+
 		setupCodeAuthenticator := credentials.NewSetupCode(setupCode)
 		c.httpClient.Options(httpclient.WithAuthenticator(setupCodeAuthenticator))
 		return nil

--- a/pkg/secrethub/client_options.go
+++ b/pkg/secrethub/client_options.go
@@ -1,6 +1,7 @@
 package secrethub
 
 import (
+	"github.com/secrethub/secrethub-go/internals/api"
 	"net/http"
 	"net/url"
 	"time"
@@ -75,6 +76,19 @@ func WithCredentials(provider credentials.Provider) ClientOption {
 		}
 		c.decrypter = decrypter
 		c.httpClient.Options(httpclient.WithAuthenticator(authenticator))
+		return nil
+	}
+}
+
+// WithSetupCode configures the client to use the provided setup code for authentication.
+func WithSetupCode(setupCode string) ClientOption {
+	return func(c *Client) error {
+		err := api.ValidateSetupCode(setupCode)
+		if err != nil {
+			return err
+		}
+		setupCodeAuthenticator := credentials.NewSetupCode(setupCode)
+		c.httpClient.Options(httpclient.WithAuthenticator(setupCodeAuthenticator))
 		return nil
 	}
 }

--- a/pkg/secrethub/client_options.go
+++ b/pkg/secrethub/client_options.go
@@ -1,10 +1,11 @@
 package secrethub
 
 import (
-	"github.com/secrethub/secrethub-go/internals/api"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/secrethub/secrethub-go/internals/api"
 
 	"github.com/secrethub/secrethub-go/pkg/secrethub/configdir"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"

--- a/pkg/secrethub/credentials.go
+++ b/pkg/secrethub/credentials.go
@@ -45,6 +45,9 @@ func (s credentialService) Create(creator credentials.Creator, description strin
 	var err error
 	if !s.isKeyed() {
 		accountKey, err = generateAccountKey()
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		key, err := s.client.getAccountKey()
 		if err != nil {

--- a/pkg/secrethub/credentials/setup_code.go
+++ b/pkg/secrethub/credentials/setup_code.go
@@ -1,0 +1,24 @@
+package credentials
+
+import (
+	"fmt"
+	"github.com/secrethub/secrethub-go/internals/auth"
+	"net/http"
+)
+
+type SetupCode struct {
+	code string
+}
+
+func NewSetupCode(code string) *SetupCode {
+	return &SetupCode{
+		code:code,
+	}
+}
+
+// Authenticate authenticates the given request with a setup code, by providing the "SetupCode" tag and the setup code
+// in the "Authorization" header.
+func (s *SetupCode) Authenticate(r *http.Request) error {
+	r.Header.Set("Authorization", fmt.Sprintf("%s-%s %s", auth.AuthHeaderVersionV1, "SetupCode", s.code))
+	return nil
+}

--- a/pkg/secrethub/credentials/setup_code.go
+++ b/pkg/secrethub/credentials/setup_code.go
@@ -2,8 +2,9 @@ package credentials
 
 import (
 	"fmt"
-	"github.com/secrethub/secrethub-go/internals/auth"
 	"net/http"
+
+	"github.com/secrethub/secrethub-go/internals/auth"
 )
 
 type SetupCode struct {
@@ -12,7 +13,7 @@ type SetupCode struct {
 
 func NewSetupCode(code string) *SetupCode {
 	return &SetupCode{
-		code:code,
+		code: code,
 	}
 }
 

--- a/pkg/secrethub/internals/http/client.go
+++ b/pkg/secrethub/internals/http/client.go
@@ -832,6 +832,10 @@ func (c *Client) do(rawURL string, method string, authenticate bool, expectedSta
 	return nil
 }
 
+func (c *Client) IsAuthenticated() bool {
+	return c.authenticator != nil
+}
+
 func joinURL(base url.URL, paths ...string) url.URL {
 	for _, path := range paths {
 		base.Path += "/" + strings.Trim(path, "/")


### PR DESCRIPTION
This PR adds the `WithSetupCode` client option, that makes the client use the supplied setup code for authorizing its requests.