### PR TITLE
Resolve and ResolveEnv

### DIFF
--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -2,7 +2,6 @@
 // look here to read, write and manage secrets.
 package secrethub
 
-import "C"
 import (
 	"os"
 	"regexp"
@@ -290,35 +289,4 @@ func (c *Client) userAgent() string {
 	userAgent += " (" + osName + "; " + runtime.GOARCH + ")"
 
 	return userAgent
-}
-
-// Resolve fetches the value of a secret, when the `ref` parameter has the
-// format `secrethub://<path>`. Otherwise it returns `ref` unchanged, as an array of bytes.
-func (c *Client) Resolve(ref string) ([]byte, error) {
-	bits := strings.Split(ref, "://")
-	if len(bits) == 2 && bits[0] == "secrethub" {
-		secret, err := c.Secrets().Read(bits[1])
-		if err != nil {
-			return []byte{}, err
-		}
-		return secret.Data, nil
-	}
-	return []byte(ref), nil
-}
-
-// ResolveEnv takes a map of environment variables and replaces the values of those
-// which store references of secrets in SecretHub (`secrethub://<path>`) with the value
-// of the respective secret. The other entries in the map remain untouched.
-func (c *Client) ResolveEnv() (map[string]string, error) {
-	envVars := os.Environ()
-	resolvedEnv := make(map[string]string, len(envVars))
-	for _, value := range envVars {
-		keyValue := strings.Split(value, "=")
-		secretValue, err := c.Resolve(keyValue[1])
-		if err != nil {
-			return map[string]string{}, err
-		}
-		resolvedEnv[keyValue[0]] = string(secretValue)
-	}
-	return resolvedEnv, nil
 }

--- a/pkg/secrethub/fakeclient/secret.go
+++ b/pkg/secrethub/fakeclient/secret.go
@@ -19,7 +19,17 @@ type SecretService struct {
 	ExistsFunc         func(path string) (bool, error)
 	WriteFunc          func(path string, data []byte) (*api.SecretVersion, error)
 	ListEventsFunc     func(path string, subjectTypes api.AuditSubjectTypeList) ([]*api.Audit, error)
+	ResolveFunc        func(ref string) ([]byte, error)
+	ResolveEnvFunc     func(envVars []string) (map[string]string, error)
 	AuditEventIterator *AuditEventIterator
+}
+
+func (s *SecretService) Resolve(ref string) ([]byte, error) {
+	return s.ResolveFunc(ref)
+}
+
+func (s *SecretService) ResolveEnv(envVars []string) (map[string]string, error) {
+	return s.ResolveEnvFunc(envVars)
 }
 
 // Delete implements the SecretService interface Delete function.


### PR DESCRIPTION
This PR contains the following new functionality to the client:
 - Resolve fetches the values of a secret from SecretHub, when the `ref` parameter has the format `secrethub://<path>`
 - ResolveEnv takes a map of environment variables and replaces the values of those which store references of secrets in SecretHub (`secrethub://<path>`) with the value of the respective secret.