### PR TITLE
Improve authentication errors

### DIFF
--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -144,7 +144,7 @@ func NewClient(with ...ClientOption) (*Client, error) {
 		var provider credentials.Provider
 		switch strings.ToLower(identityProvider) {
 		case "", "key":
-			provider = credentials.UseKey(client.DefaultCredential())
+			provider = credentials.UseKey(client.DefaultCredential(), credentials.DefaultKeyDecoder())
 		case "aws":
 			provider = credentials.UseAWS()
 		case "gcp":
@@ -153,7 +153,7 @@ func NewClient(with ...ClientOption) (*Client, error) {
 			return nil, ErrUnknownIdentityProvider(identityProvider)
 		}
 
-		err := client.with(WithCredentials(provider))
+		err = client.with(WithCredentials(provider))
 		// nolint: staticcheck
 		if err != configdir.ErrCredentialNotFound {
 			return nil, err
@@ -265,7 +265,7 @@ func (c *Client) with(options ...ClientOption) error {
 // DefaultCredential returns a reader pointing to the configured credential,
 // sourcing it either from the SECRETHUB_CREDENTIAL environment variable or
 // from the configuration directory.
-func (c *Client) DefaultCredential() credentials.Reader {
+func (c *Client) DefaultCredential() credentials.KeyReader {
 	envCredential := os.Getenv("SECRETHUB_CREDENTIAL")
 	if envCredential != "" {
 		return credentials.FromString(envCredential)

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -266,9 +266,10 @@ func (c *Client) with(options ...ClientOption) error {
 // sourcing it either from the SECRETHUB_CREDENTIAL environment variable or
 // from the configuration directory.
 func (c *Client) DefaultCredential() credentials.KeyReader {
-	envCredential := os.Getenv("SECRETHUB_CREDENTIAL")
+	const credentialEnvVar = "SECRETHUB_CREDENTIAL"
+	envCredential := os.Getenv(credentialEnvVar)
 	if envCredential != "" {
-		return credentials.FromString(envCredential)
+		return credentials.FromEnv(credentialEnvVar)
 	}
 
 	return c.ConfigDir.Credential()

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -155,7 +155,7 @@ func NewClient(with ...ClientOption) (*Client, error) {
 
 		err = client.with(WithCredentials(provider))
 		// nolint: staticcheck
-		if err != configdir.ErrCredentialNotFound {
+		if err != configdir.ErrCredentialNotFound && err != nil {
 			return nil, err
 		} else if err != nil {
 			// TODO: log that default credential was not found.

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -155,8 +155,10 @@ func NewClient(with ...ClientOption) (*Client, error) {
 
 		err := client.with(WithCredentials(provider))
 		// nolint: staticcheck
-		if err != nil {
-			// TODO: log that default credential was not loaded.
+		if err != configdir.ErrCredentialNotFound {
+			return nil, err
+		} else if err != nil {
+			// TODO: log that default credential was not found.
 			// Do go on because we want to allow an unauthenticated client.
 		}
 	}

--- a/pkg/secrethub/configdir/dir.go
+++ b/pkg/secrethub/configdir/dir.go
@@ -5,10 +5,11 @@ package configdir
 import (
 	"errors"
 	"fmt"
-	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
 
 	"github.com/mitchellh/go-homedir"
 )

--- a/pkg/secrethub/configdir/dir.go
+++ b/pkg/secrethub/configdir/dir.go
@@ -19,6 +19,15 @@ var (
 	ErrCredentialNotFound = errors.New("credential not found")
 )
 
+type ErrDecodingCredential struct {
+	Location string
+	Err     error
+}
+
+func (e ErrDecodingCredential) Error() string {
+	return fmt.Sprintf("error decoding credential loaded from '%s': %v", e.Location, e.Err)
+}
+
 // Dir represents the configuration directory located at some path
 // on the file system.
 type Dir struct {
@@ -108,5 +117,12 @@ func (f *CredentialFile) Read(decoder credentials.KeyDecoder) (credentials.Key, 
 	if err != nil {
 		return credentials.Key{}, err
 	}
-	return decoder.Decode(bytes)
+	key, err := decoder.Decode(bytes)
+	if err != nil {
+		return credentials.Key{}, ErrDecodingCredential{
+			Location: f.path,
+			Err:      err,
+		}
+	}
+	return key, nil
 }

--- a/pkg/secrethub/configdir/dir.go
+++ b/pkg/secrethub/configdir/dir.go
@@ -5,6 +5,7 @@ package configdir
 import (
 	"errors"
 	"fmt"
+	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -95,12 +96,16 @@ func (f *CredentialFile) Exists() bool {
 }
 
 // Read reads from the filesystem and returns the contents of the credential file.
-func (f *CredentialFile) Read() ([]byte, error) {
+func (f *CredentialFile) Read(decoder credentials.KeyDecoder) (credentials.Key, error) {
 	file, err := os.Open(f.path)
 	if os.IsNotExist(err) {
-		return nil, ErrCredentialNotFound
+		return credentials.Key{}, ErrCredentialNotFound
 	} else if err != nil {
-		return nil, err
+		return credentials.Key{}, err
 	}
-	return ioutil.ReadAll(file)
+	bytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return credentials.Key{}, err
+	}
+	return decoder.Decode(bytes)
 }

--- a/pkg/secrethub/configdir/dir.go
+++ b/pkg/secrethub/configdir/dir.go
@@ -21,7 +21,7 @@ var (
 
 type ErrDecodingCredential struct {
 	Location string
-	Err     error
+	Err      error
 }
 
 func (e ErrDecodingCredential) Error() string {

--- a/pkg/secrethub/configdir/dir.go
+++ b/pkg/secrethub/configdir/dir.go
@@ -19,15 +19,6 @@ var (
 	ErrCredentialNotFound = errors.New("credential not found")
 )
 
-type ErrDecodingCredential struct {
-	Location string
-	Err      error
-}
-
-func (e ErrDecodingCredential) Error() string {
-	return fmt.Sprintf("error decoding credential loaded from '%s': %v", e.Location, e.Err)
-}
-
 // Dir represents the configuration directory located at some path
 // on the file system.
 type Dir struct {
@@ -119,7 +110,7 @@ func (f *CredentialFile) Read(decoder credentials.KeyDecoder) (credentials.Key, 
 	}
 	key, err := decoder.Decode(bytes)
 	if err != nil {
-		return credentials.Key{}, ErrDecodingCredential{
+		return credentials.Key{}, credentials.ErrDecodingCredential{
 			Location: f.path,
 			Err:      err,
 		}

--- a/pkg/secrethub/credentials/encoding.go
+++ b/pkg/secrethub/credentials/encoding.go
@@ -25,7 +25,7 @@ var (
 	ErrCannotDecodeCredentialPayload     = errCredentials.Code("invalid_credential_header").ErrorPref("cannot decode credential payload: %v")
 	ErrCannotDecodeEncryptedCredential   = errCredentials.Code("cannot_decode_encrypted_credential").Error("cannot decode an encrypted credential without a key")
 	ErrCannotDecryptCredential           = errCredentials.Code("cannot_decrypt_credential").Error("passphrase is incorrect")
-	ErrNeedPassphrase                    = errCredentials.Code("credential_passphrase_required").Error("credential is password-protected")
+	ErrNeedPassphrase                    = errCredentials.Code("credential_passphrase_required").Error("default credential is password-protected. Configure the client to use service credential by provisioning one through the SECRETHUB_CREDENTIAL environment variable")
 	ErrMalformedCredential               = errCredentials.Code("malformed_credential").ErrorPref("credential is malformed: %v")
 	ErrInvalidKey                        = errCredentials.Code("invalid_key").Error("the given key is not valid for the encryption algorithm")
 )

--- a/pkg/secrethub/credentials/encoding.go
+++ b/pkg/secrethub/credentials/encoding.go
@@ -25,6 +25,7 @@ var (
 	ErrCannotDecodeCredentialPayload     = errCredentials.Code("invalid_credential_header").ErrorPref("cannot decode credential payload: %v")
 	ErrCannotDecodeEncryptedCredential   = errCredentials.Code("cannot_decode_encrypted_credential").Error("cannot decode an encrypted credential without a key")
 	ErrCannotDecryptCredential           = errCredentials.Code("cannot_decrypt_credential").Error("passphrase is incorrect")
+	ErrNeedPassphrase                    = errCredentials.Code("credential_passphrase_required").Error("credential is password-protected")
 	ErrMalformedCredential               = errCredentials.Code("malformed_credential").ErrorPref("credential is malformed: %v")
 	ErrInvalidKey                        = errCredentials.Code("invalid_key").Error("the given key is not valid for the encryption algorithm")
 )

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -70,7 +70,7 @@ func ImportKey(credentialReader, passphraseReader Reader) (Key, error) {
 	}
 	if encoded.IsEncrypted() {
 		if passphraseReader == nil {
-			return Key{}, errors.New("need passphrase")
+			return Key{}, ErrNeedPassphrase
 		}
 
 		// Try up to three times to get the correct passphrase.

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"errors"
+
 	"github.com/secrethub/secrethub-go/internals/auth"
 	"github.com/secrethub/secrethub-go/internals/crypto"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/internals/http"

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -56,11 +56,20 @@ func (k Key) Export() ([]byte, error) {
 }
 
 type KeyDecoder interface {
-	WithPassphrase(passphraseReader Reader)
 	Decode([]byte) (Key, error)
 }
 
-type credentialDecoder struct{
+func DefaultKeyDecoder() KeyDecoder {
+	return credentialDecoder{}
+}
+
+func KeyDecoderWithPassphrase(passphraseReader Reader) KeyDecoder {
+	return credentialDecoder{
+		passphraseReader: passphraseReader,
+	}
+}
+
+type credentialDecoder struct {
 	passphraseReader Reader
 }
 

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -11,7 +11,7 @@ import (
 // Key is a credential that uses a local key for all its operations.
 type Key struct {
 	key              *RSACredential
-	exportPassphrase Reader
+	exportPassphrase PassphraseReader
 }
 
 // Verifier returns a Verifier that can be used for creating a new credential from this Key.
@@ -31,7 +31,7 @@ func (k Key) Provide(httpClient *http.Client) (auth.Authenticator, Decrypter, er
 
 // Passphrase returns a new Key that uses the provided passphraseReader to obtain a passphrase that is used for
 // encryption when Export() is called.
-func (k Key) Passphrase(passphraseReader Reader) Key {
+func (k Key) Passphrase(passphraseReader PassphraseReader) Key {
 	k.exportPassphrase = passphraseReader
 	return k
 }
@@ -64,14 +64,14 @@ func DefaultKeyDecoder() KeyDecoder {
 	return credentialDecoder{}
 }
 
-func KeyDecoderWithPassphrase(passphraseReader Reader) KeyDecoder {
+func KeyDecoderWithPassphrase(passphraseReader PassphraseReader) KeyDecoder {
 	return credentialDecoder{
 		passphraseReader: passphraseReader,
 	}
 }
 
 type credentialDecoder struct {
-	passphraseReader Reader
+	passphraseReader PassphraseReader
 }
 
 func (d credentialDecoder) Decode(bytes []byte) (Key, error) {

--- a/pkg/secrethub/credentials/providers.go
+++ b/pkg/secrethub/credentials/providers.go
@@ -23,8 +23,8 @@ func UseKey(credentialReader KeyReader, decoder KeyDecoder) KeyProvider {
 	}
 }
 
-// KeyProvider is a Provider that reads a key from a Reader.
-// If the key is encrypted with a passphrase, Passphrase() should be called on the KeyProvider to set the Reader that
+// KeyProvider is a Provider that reads a key from a PassphraseReader.
+// If the key is encrypted with a passphrase, Passphrase() should be called on the KeyProvider to set the PassphraseReader that
 // provides the passphrase that can be used to decrypt the key.
 type KeyProvider struct {
 	credentialReader KeyReader

--- a/pkg/secrethub/credentials/providers.go
+++ b/pkg/secrethub/credentials/providers.go
@@ -19,7 +19,7 @@ type Provider interface {
 func UseKey(credentialReader KeyReader, decoder KeyDecoder) KeyProvider {
 	return KeyProvider{
 		credentialReader: credentialReader,
-		decoder: decoder,
+		decoder:          decoder,
 	}
 }
 
@@ -28,7 +28,7 @@ func UseKey(credentialReader KeyReader, decoder KeyDecoder) KeyProvider {
 // provides the passphrase that can be used to decrypt the key.
 type KeyProvider struct {
 	credentialReader KeyReader
-	decoder KeyDecoder
+	decoder          KeyDecoder
 }
 
 func (k KeyProvider) Decoder(keyDecoder KeyDecoder) Provider {

--- a/pkg/secrethub/credentials/providers.go
+++ b/pkg/secrethub/credentials/providers.go
@@ -16,9 +16,10 @@ type Provider interface {
 // Usage:
 //		credentials.UseKey(credentials.FromString("<a credential>"))
 //		credentials.UseKey(credentials.FromFile("/path/to/credential")).Passphrase(credentials.FromString("passphrase"))
-func UseKey(credentialReader Reader) KeyProvider {
+func UseKey(credentialReader KeyReader, decoder KeyDecoder) KeyProvider {
 	return KeyProvider{
 		credentialReader: credentialReader,
+		decoder: decoder,
 	}
 }
 
@@ -26,19 +27,18 @@ func UseKey(credentialReader Reader) KeyProvider {
 // If the key is encrypted with a passphrase, Passphrase() should be called on the KeyProvider to set the Reader that
 // provides the passphrase that can be used to decrypt the key.
 type KeyProvider struct {
-	credentialReader Reader
-	passphraseReader Reader
+	credentialReader KeyReader
+	decoder KeyDecoder
 }
 
-// Passphrase returns a new Provider that uses the passphraseReader to read a passphrase if the read key is encrypted.
-func (k KeyProvider) Passphrase(passphraseReader Reader) Provider {
-	k.passphraseReader = passphraseReader
+func (k KeyProvider) Decoder(keyDecoder KeyDecoder) Provider {
+	k.decoder = keyDecoder
 	return k
 }
 
 // Provide implements the Provider interface for a KeyProvider.
 func (k KeyProvider) Provide(httpClient *http.Client) (auth.Authenticator, Decrypter, error) {
-	key, err := ImportKey(k.credentialReader, k.passphraseReader)
+	key, err := k.credentialReader.Read(k.decoder)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -1,10 +1,19 @@
 package credentials
 
 import (
-	"github.com/secrethub/secrethub-go/pkg/secrethub/configdir"
+	"fmt"
 	"io/ioutil"
 	"os"
 )
+
+type ErrDecodingCredential struct {
+	Location string
+	Err      error
+}
+
+func (e ErrDecodingCredential) Error() string {
+	return fmt.Sprintf("error decoding credential loaded from '%s': %v", e.Location, e.Err)
+}
 
 // PassphraseReader helps with reading bytes from a configured source.
 type PassphraseReader interface {
@@ -40,7 +49,7 @@ func FromFile(path string) KeyReader {
 		}
 		key, err := decoder.Decode(keyBytes)
 		if err != nil {
-			return Key{}, configdir.ErrDecodingCredential{
+			return Key{}, ErrDecodingCredential{
 				Location: path,
 				Err:      err,
 			}
@@ -55,7 +64,7 @@ func FromEnv(envVarKey string) KeyReader {
 	return keyReaderFunc(func(decoder KeyDecoder) (Key, error) {
 		key, err := decoder.Decode([]byte(os.Getenv(envVarKey)))
 		if err != nil {
-			return Key{}, configdir.ErrDecodingCredential{
+			return Key{}, ErrDecodingCredential{
 				Location: "$" + envVarKey,
 				Err:      err,
 			}

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -11,36 +11,52 @@ type Reader interface {
 	Read() ([]byte, error)
 }
 
+type KeyReader interface {
+	Read(decoder KeyDecoder) (Key, error)
+}
+
 // FromFile returns a reader that reads the contents of a file,
 // e.g. a credential or a passphrase.
-func FromFile(path string) Reader {
-	return readerFunc(func() ([]byte, error) {
+func FromFile(path string) KeyReader {
+	return keyReaderFunc(func() ([]byte, error) {
 		return ioutil.ReadFile(path)
 	})
 }
 
 // FromEnv returns a reader that reads the contents of an
 // environment variable, e.g. a credential or a passphrase.
-func FromEnv(key string) Reader {
-	return readerFunc(func() ([]byte, error) {
+func FromEnv(key string) KeyReader {
+	return keyReaderFunc(func() ([]byte, error) {
 		return []byte(os.Getenv(key)), nil
 	})
 }
 
 // FromBytes returns a reader that simply returns the given bytes
 // when Read() is called.
-func FromBytes(raw []byte) Reader {
-	return readerFunc(func() ([]byte, error) {
+func FromBytes(raw []byte) KeyReader {
+	return keyReaderFunc(func() ([]byte, error) {
 		return raw, nil
 	})
 }
 
 // FromString returns a reader that simply returns the given string as
 // a byte slice when Read() is called.
-func FromString(raw string) Reader {
-	return readerFunc(func() ([]byte, error) {
+func FromString(raw string) KeyReader {
+	return keyReaderFunc(func() ([]byte, error) {
 		return []byte(raw), nil
 	})
+}
+
+// keyReaderFunc is a helper function to create a reader from any func() ([]byte, error).
+type keyReaderFunc func() ([]byte, error)
+
+// Read implements the Reader interface.
+func (f keyReaderFunc) Read(decoder KeyDecoder) (Key, error) {
+	keyBytes, err := f()
+	if err != nil {
+		return Key{}, err
+	}
+	return decoder.Decode(keyBytes)
 }
 
 // readerFunc is a helper function to create a reader from any func() ([]byte, error).

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -58,11 +58,3 @@ func (f keyReaderFunc) Read(decoder KeyDecoder) (Key, error) {
 	}
 	return decoder.Decode(keyBytes)
 }
-
-// readerFunc is a helper function to create a reader from any func() ([]byte, error).
-type readerFunc func() ([]byte, error)
-
-// Read implements the Reader interface.
-func (f readerFunc) Read() ([]byte, error) {
-	return f()
-}

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -1,6 +1,7 @@
 package credentials
 
 import (
+	"github.com/secrethub/secrethub-go/pkg/secrethub/configdir"
 	"io/ioutil"
 	"os"
 )
@@ -37,7 +38,14 @@ func FromFile(path string) KeyReader {
 		if err != nil {
 			return Key{}, err
 		}
-		return decoder.Decode(keyBytes)
+		key, err := decoder.Decode(keyBytes)
+		if err != nil {
+			return Key{}, configdir.ErrDecodingCredential{
+				Location: path,
+				Err:      err,
+			}
+		}
+		return key, nil
 	})
 }
 

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -5,8 +5,8 @@ import (
 	"os"
 )
 
-// Reader helps with reading bytes from a configured source.
-type Reader interface {
+// PassphraseReader helps with reading bytes from a configured source.
+type PassphraseReader interface {
 	// Read reads from the reader and returns the resulting bytes.
 	Read() ([]byte, error)
 }

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -15,6 +15,12 @@ func (e ErrDecodingCredential) Error() string {
 	return fmt.Sprintf("error decoding credential loaded from '%s': %v", e.Location, e.Err)
 }
 
+// Reader helps with reading bytes from a configured source.
+type Reader interface {
+	// Read reads from the reader and returns the resulting bytes.
+	Read() ([]byte, error)
+}
+
 // PassphraseReader helps with reading bytes from a configured source.
 type PassphraseReader interface {
 	// Read reads from the reader and returns the resulting bytes.

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -11,6 +11,20 @@ type PassphraseReader interface {
 	Read() ([]byte, error)
 }
 
+type passphraseReader func() ([]byte, error)
+
+func (p passphraseReader) Read() ([]byte, error) {
+	return p()
+}
+
+// PassphraseFromString returns a reader that simply returns the given string as
+// a byte slice when Read() is called.
+func PassphraseFromString(passphrase string) PassphraseReader {
+	return passphraseReader(func() ([]byte, error) {
+		return []byte(passphrase), nil
+	})
+}
+
 type KeyReader interface {
 	Read(decoder KeyDecoder) (Key, error)
 }

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -51,9 +51,16 @@ func FromFile(path string) KeyReader {
 
 // FromEnv returns a reader that reads the contents of an
 // environment variable, e.g. a credential or a passphrase.
-func FromEnv(key string) KeyReader {
+func FromEnv(envVarKey string) KeyReader {
 	return keyReaderFunc(func(decoder KeyDecoder) (Key, error) {
-		return decoder.Decode([]byte(os.Getenv(key)))
+		key, err := decoder.Decode([]byte(os.Getenv(envVarKey)))
+		if err != nil {
+			return Key{}, configdir.ErrDecodingCredential{
+				Location: "$" + envVarKey,
+				Err:      err,
+			}
+		}
+		return key, nil
 	})
 }
 


### PR DESCRIPTION
Currently if any errors occur when providing credentials to the client, these errors are discarded and a `Request not authenticated` error is returned when the first request that requires authentication is made.

This error is vague and can be unhelpful: For example when using the .NET / Go client with a password protected credential, `request not authenticated` does not really address the underlying issue of not being able to use password protected credentials with these clients.

To address this issue, this PR makes the client constructor only ignore `Credential not found` errors, as the only case in which an unauthenticated client is desired is before the user signs up with the CLI. Any other errors (malformed credential, password-protected credential is used with the Go / .NET client, AWS/GCP credential errors) will all be returned when constructing the client.

A new error type has been added to provide a better error message for the error related to password-protected credentials.

**Note that this PR breaks backwards compatibility**, as previously in case of any credential provisioning errors (e.g. malformed credential, aws errors, etc.) an unauthenticated client was returned. After this change the error will be returned instead.

Moreover the credential decoding errors have been wrapped in an error containing the source of the credential, to ease identifying and fixing issues. The error has the following format:
`error decoding credential loaded from '~/.secrethub/credential': ...` or
`error decoding credential loaded from '$SECRETHUB_CREDENTIAL': ...`