### PR TITLE
Improve Credential Errors

### DIFF
--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -264,9 +264,10 @@ func (c *Client) with(options ...ClientOption) error {
 // sourcing it either from the SECRETHUB_CREDENTIAL environment variable or
 // from the configuration directory.
 func (c *Client) DefaultCredential() credentials.Reader {
-	envCredential := os.Getenv("SECRETHUB_CREDENTIAL")
+	const credentialEnvironmentVariable = "SECRETHUB_CREDENTIAL"
+	envCredential := os.Getenv(credentialEnvironmentVariable)
 	if envCredential != "" {
-		return credentials.FromString(envCredential)
+		return credentials.FromEnv(credentialEnvironmentVariable)
 	}
 
 	return c.ConfigDir.Credential()

--- a/pkg/secrethub/client_options.go
+++ b/pkg/secrethub/client_options.go
@@ -78,3 +78,12 @@ func WithCredentials(provider credentials.Provider) ClientOption {
 		return nil
 	}
 }
+
+// WithDefaultPassphraseReader sets a default passphrase reader that is used for decrypting an encrypted key credential
+// if no credential is set explicitly.
+func WithDefaultPassphraseReader(reader credentials.Reader) ClientOption {
+	return func(c *Client) error {
+		c.defaultPassphraseReader = reader
+		return nil
+	}
+}

--- a/pkg/secrethub/configdir/dir.go
+++ b/pkg/secrethub/configdir/dir.go
@@ -77,6 +77,11 @@ func (f *CredentialFile) Path() string {
 	return f.path
 }
 
+// Source returns the path to the credential file.
+func (f *CredentialFile) Source() string {
+	return f.path
+}
+
 // Write writes the given bytes to the credential file.
 func (f *CredentialFile) Write(data []byte) error {
 	err := os.MkdirAll(filepath.Dir(f.path), os.FileMode(0700))

--- a/pkg/secrethub/credentials/encoding.go
+++ b/pkg/secrethub/credentials/encoding.go
@@ -25,7 +25,7 @@ var (
 	ErrCannotDecodeCredentialPayload     = errCredentials.Code("invalid_credential_header").ErrorPref("cannot decode credential payload: %v")
 	ErrCannotDecodeEncryptedCredential   = errCredentials.Code("cannot_decode_encrypted_credential").Error("cannot decode an encrypted credential without a key")
 	ErrCannotDecryptCredential           = errCredentials.Code("cannot_decrypt_credential").Error("passphrase is incorrect")
-	ErrNeedPassphrase                    = errCredentials.Code("credential_passphrase_required").Error("default credential is password-protected. Configure the client to use service credential by provisioning one through the SECRETHUB_CREDENTIAL environment variable")
+	ErrNeedPassphrase                    = errCredentials.Code("credential_passphrase_required").Error("credential is password-protected. Configure the client to use service credential by provisioning one through the SECRETHUB_CREDENTIAL environment variable")
 	ErrMalformedCredential               = errCredentials.Code("malformed_credential").ErrorPref("credential is malformed: %v")
 	ErrInvalidKey                        = errCredentials.Code("invalid_key").Error("the given key is not valid for the encryption algorithm")
 )

--- a/pkg/secrethub/credentials/encoding.go
+++ b/pkg/secrethub/credentials/encoding.go
@@ -25,7 +25,7 @@ var (
 	ErrCannotDecodeCredentialPayload     = errCredentials.Code("invalid_credential_header").ErrorPref("cannot decode credential payload: %v")
 	ErrCannotDecodeEncryptedCredential   = errCredentials.Code("cannot_decode_encrypted_credential").Error("cannot decode an encrypted credential without a key")
 	ErrCannotDecryptCredential           = errCredentials.Code("cannot_decrypt_credential").Error("passphrase is incorrect")
-	ErrNeedPassphrase                    = errCredentials.Code("credential_passphrase_required").Error("credential is password-protected. Configure the client to use service credential by provisioning one through the SECRETHUB_CREDENTIAL environment variable")
+	ErrNeedPassphrase                    = errCredentials.Code("credential_passphrase_required").Error("credential is password-protected. Configure a credential passphrase through the SECRETHUB_CREDENTIAL_PASSPHRASE environment variable or use a credential that is not password-protected")
 	ErrMalformedCredential               = errCredentials.Code("malformed_credential").ErrorPref("credential is malformed: %v")
 	ErrInvalidKey                        = errCredentials.Code("invalid_key").Error("the given key is not valid for the encryption algorithm")
 )

--- a/pkg/secrethub/credentials/encoding.go
+++ b/pkg/secrethub/credentials/encoding.go
@@ -25,6 +25,7 @@ var (
 	ErrCannotDecodeCredentialPayload     = errCredentials.Code("invalid_credential_header").ErrorPref("cannot decode credential payload: %v")
 	ErrCannotDecodeEncryptedCredential   = errCredentials.Code("cannot_decode_encrypted_credential").Error("cannot decode an encrypted credential without a key")
 	ErrCannotDecryptCredential           = errCredentials.Code("cannot_decrypt_credential").Error("passphrase is incorrect")
+	ErrNeedPassphrase                    = errCredentials.Code("credential_passphrase_required").Error("default credential is password-protected. Configure the client to use service credential by provisioning one through the SECRETHUB_CREDENTIAL environment variable")
 	ErrMalformedCredential               = errCredentials.Code("malformed_credential").ErrorPref("credential is malformed: %v")
 	ErrInvalidKey                        = errCredentials.Code("invalid_key").Error("the given key is not valid for the encryption algorithm")
 )

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -2,11 +2,21 @@ package credentials
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/secrethub/secrethub-go/internals/auth"
 	"github.com/secrethub/secrethub-go/internals/crypto"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/internals/http"
 )
+
+type ErrLoadingCredential struct {
+	Location string
+	Err      error
+}
+
+func (e ErrLoadingCredential) Error() string {
+	return fmt.Sprintf("error loading credential loaded from '%s': %v", e.Location, e.Err)
+}
 
 // Key is a credential that uses a local key for all its operations.
 type Key struct {

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -80,7 +80,7 @@ func ImportKey(credentialReader, passphraseReader Reader) (Key, error) {
 	}
 	if encoded.IsEncrypted() {
 		if passphraseReader == nil {
-			return Key{}, errors.New("need passphrase")
+			return Key{}, ErrNeedPassphrase
 		}
 
 		// Try up to three times to get the correct passphrase.

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/secrethub/secrethub-go/internals/auth"
@@ -79,11 +80,12 @@ func ImportKey(credentialReader, passphraseReader Reader) (Key, error) {
 		return Key{}, err
 	}
 	if encoded.IsEncrypted() {
-		envPassphrase := os.Getenv("SECRETHUB_CREDENTIAL_PASSPHRASE")
+		const credentialPassphraseEnvVar = "SECRETHUB_CREDENTIAL_PASSPHRASE"
+		envPassphrase := os.Getenv(credentialPassphraseEnvVar)
 		if envPassphrase != "" {
 			credential, err := decryptKey([]byte(envPassphrase), encoded)
 			if err != nil {
-				return Key{}, err
+				return Key{}, fmt.Errorf("decrypting credential with passphrase read from $%s: %v", credentialPassphraseEnvVar, err)
 			}
 			return Key{key: credential}, nil
 		}

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -16,7 +16,7 @@ type ErrLoadingCredential struct {
 }
 
 func (e ErrLoadingCredential) Error() string {
-	return fmt.Sprintf("error loading credential loaded from '%s': %v", e.Location, e.Err)
+	return "load credential " + e.Location + ": " + e.Err.Error()
 }
 
 // Key is a credential that uses a local key for all its operations.

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -89,7 +89,7 @@ func ImportKey(credentialReader, passphraseReader Reader) (Key, error) {
 			if err != nil {
 				return Key{}, err
 			}
-			return Key{key:credential}, nil
+			return Key{key: credential}, nil
 		}
 
 		// Try up to three times to get the correct passphrase.

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -2,7 +2,6 @@ package credentials
 
 import (
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/secrethub/secrethub-go/internals/auth"

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -81,15 +81,15 @@ func ImportKey(credentialReader, passphraseReader Reader) (Key, error) {
 	}
 	if encoded.IsEncrypted() {
 		envPassphrase := os.Getenv("SECRETHUB_CREDENTIAL_PASSPHRASE")
-		if passphraseReader == nil && envPassphrase == "" {
-			return Key{}, ErrNeedPassphrase
-		}
-		if passphraseReader == nil {
+		if envPassphrase != "" {
 			credential, err := decryptKey([]byte(envPassphrase), encoded)
 			if err != nil {
 				return Key{}, err
 			}
 			return Key{key: credential}, nil
+		}
+		if passphraseReader == nil {
+			return Key{}, ErrNeedPassphrase
 		}
 
 		// Try up to three times to get the correct passphrase.

--- a/pkg/secrethub/credentials/providers.go
+++ b/pkg/secrethub/credentials/providers.go
@@ -39,7 +39,12 @@ func (k KeyProvider) Passphrase(passphraseReader Reader) Provider {
 // Provide implements the Provider interface for a KeyProvider.
 func (k KeyProvider) Provide(httpClient *http.Client) (auth.Authenticator, Decrypter, error) {
 	key, err := ImportKey(k.credentialReader, k.passphraseReader)
-	if err != nil {
+	if source, ok := k.credentialReader.(CredentialSource); ok && err != nil {
+		return nil, nil, ErrLoadingCredential{
+			Location: source.Source(),
+			Err:      err,
+		}
+	} else if err != nil {
 		return nil, nil, err
 	}
 	return key.Provide(httpClient)
@@ -51,4 +56,10 @@ type providerFunc func(*http.Client) (auth.Authenticator, Decrypter, error)
 // Provide lets providerFunc implement the Provider interface.
 func (f providerFunc) Provide(httpClient *http.Client) (auth.Authenticator, Decrypter, error) {
 	return f(httpClient)
+}
+
+// CredentialSource should be implemented by credential readers to allow returning credential reading errors
+// that include the credentials source (e.g. path to credential file, environment variable etc.).
+type CredentialSource interface {
+	Source() string
 }

--- a/pkg/secrethub/credentials/providers.go
+++ b/pkg/secrethub/credentials/providers.go
@@ -39,12 +39,13 @@ func (k KeyProvider) Passphrase(passphraseReader Reader) Provider {
 // Provide implements the Provider interface for a KeyProvider.
 func (k KeyProvider) Provide(httpClient *http.Client) (auth.Authenticator, Decrypter, error) {
 	key, err := ImportKey(k.credentialReader, k.passphraseReader)
-	if source, ok := k.credentialReader.(CredentialSource); ok && err != nil {
-		return nil, nil, ErrLoadingCredential{
-			Location: source.Source(),
-			Err:      err,
+	if err != nil {
+		if source, ok := k.credentialReader.(CredentialSource); ok {
+			return nil, nil, ErrLoadingCredential{
+				Location: source.Source(),
+				Err:      err,
+			}
 		}
-	} else if err != nil {
 		return nil, nil, err
 	}
 	return key.Provide(httpClient)

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -22,8 +22,9 @@ func FromFile(path string) Reader {
 // FromEnv returns a reader that reads the contents of an
 // environment variable, e.g. a credential or a passphrase.
 func FromEnv(key string) Reader {
+	credential := os.Getenv(key)
 	return newReader("$"+key, func() ([]byte, error) {
-		return []byte(os.Getenv(key)), nil
+		return []byte(credential), nil
 	})
 }
 

--- a/pkg/secrethub/credentials/readers.go
+++ b/pkg/secrethub/credentials/readers.go
@@ -22,9 +22,8 @@ func FromFile(path string) Reader {
 // FromEnv returns a reader that reads the contents of an
 // environment variable, e.g. a credential or a passphrase.
 func FromEnv(key string) Reader {
-	credential := os.Getenv(key)
 	return newReader("$"+key, func() ([]byte, error) {
-		return []byte(credential), nil
+		return []byte(os.Getenv(key)), nil
 	})
 }
 


### PR DESCRIPTION
This PR:
- improves the error returned when the credential is password-protected, but no passphrase reader is provided.
- wraps all errors that occur when loading a credential with a message that includes the credential's source
- adds the `SECRETHUB_CREDENTIAL_PASSPHRASE` environment variable, which is checked if no passphrase reader is provided, but the credential is password-protected