### PR TITLE
Add option set set a default passphrase reader

### DIFF
--- a/pkg/secrethub/client_options.go
+++ b/pkg/secrethub/client_options.go
@@ -78,3 +78,12 @@ func WithCredentials(provider credentials.Provider) ClientOption {
 		return nil
 	}
 }
+
+// WithDefaultPassphraseReader sets a default passphrase reader that is used for decrypting an encrypted key credential
+// if no credential is set explicitly.
+func WithDefaultPassphraseReader(reader credentials.Reader) ClientOption {
+	return func(c *Client) error {
+		c.defaultPassphraseReader = reader
+		return nil
+	}
+}


### PR DESCRIPTION
This allows setting a passphrase without having to provide a credential itself, which can be used to make configuring the Terraform provider easier.