### PR TITLE
Configure the remote server with SECRETHUB_API_REMOTE envvar

### DIFF
--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -181,6 +181,14 @@ func NewClient(with ...ClientOption) (*Client, error) {
 
 	client.httpClient.Options(http.WithUserAgent(userAgent))
 
+	apiRemote := os.Getenv("SECRETHUB_API_REMOTE")
+	if apiRemote != "" {
+		err := client.with(WithServerURL(apiRemote))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return client, nil
 }
 


### PR DESCRIPTION
Just like the CLI already checks the `SECRETHUB_API_REMOTE` envvar, the SDK now also accepts the same envvar.

This also makes it possible to use this envvar in other projects, for example the [Terraform provider](https://github.com/secrethub/terraform-provider-secrethub), if they upgrade the SDK to a version including this commit.