### PR TITLE
Fix error handling of credential loading

### DIFF
--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -121,11 +121,11 @@ func (i AppInfo) ValidateName() error {
 // If no key credential could be found, a Client is returned that can only be used for unauthenticated routes.
 func NewClient(with ...ClientOption) (*Client, error) {
 	client := &Client{
-		httpClient:              http.NewClient(),
-		repoIndexKeys:           make(map[api.RepoPath]*crypto.SymmetricKey),
-		appInfo:                 []*AppInfo{},
-		defaultPassphraseReader: credentials.FromEnv("SECRETHUB_CREDENTIAL_PASSPHRASE"),
+		httpClient:    http.NewClient(),
+		repoIndexKeys: make(map[api.RepoPath]*crypto.SymmetricKey),
+		appInfo:       []*AppInfo{},
 	}
+
 	err := client.with(with...)
 	if err != nil {
 		return nil, err

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -157,10 +157,8 @@ func NewClient(with ...ClientOption) (*Client, error) {
 		}
 
 		err := client.with(WithCredentials(provider))
-		// nolint: staticcheck
 		if err != nil {
-			// TODO: log that default credential was not loaded.
-			// Do go on because we want to allow an unauthenticated client.
+			return nil, err
 		}
 	}
 

--- a/pkg/secrethub/client.go
+++ b/pkg/secrethub/client.go
@@ -162,19 +162,7 @@ func NewClient(with ...ClientOption) (*Client, error) {
 		}
 	}
 
-	appName := os.Getenv("SECRETHUB_APP_INFO_NAME")
-	if appName != "" {
-		appVersion := os.Getenv("SECRETHUB_APP_INFO_VERSION")
-		topLevelAppInfo := &AppInfo{
-			Name:    appName,
-			Version: appVersion,
-		}
-		// Ignore app info from environment variable if name is invalid
-		if err = topLevelAppInfo.ValidateName(); err == nil {
-			client.appInfo = append(client.appInfo, topLevelAppInfo)
-		}
-	}
-
+	client.loadAppInfoFromEnv()
 	userAgent := client.userAgent()
 
 	client.httpClient.Options(http.WithUserAgent(userAgent))
@@ -284,6 +272,21 @@ func (c *Client) DefaultCredential() credentials.Reader {
 
 func (c *Client) isKeyed() bool {
 	return c.decrypter != nil
+}
+
+func (c *Client) loadAppInfoFromEnv() {
+	appName := os.Getenv("SECRETHUB_APP_INFO_NAME")
+	if appName != "" {
+		appVersion := os.Getenv("SECRETHUB_APP_INFO_VERSION")
+		topLevelAppInfo := &AppInfo{
+			Name:    appName,
+			Version: appVersion,
+		}
+		// Ignore app info from environment variable if name is invalid
+		if err := topLevelAppInfo.ValidateName(); err == nil {
+			c.appInfo = append(c.appInfo, topLevelAppInfo)
+		}
+	}
 }
 
 func (c *Client) userAgent() string {

--- a/pkg/secrethub/client_test.go
+++ b/pkg/secrethub/client_test.go
@@ -62,11 +62,11 @@ func TestClient_userAgent(t *testing.T) {
 			for _, info := range tc.appInfo {
 				opts = append(opts, WithAppInfo(info))
 			}
-			client, err := NewClient(opts...)
+			client := &Client{}
+			err := client.with(opts...)
 			assert.Equal(t, err, tc.err)
-			if err != nil {
-				return
-			}
+
+			client.loadAppInfoFromEnv()
 
 			userAgent := client.userAgent()
 			pattern := tc.expected + " \\(.*\\)"

--- a/pkg/secrethub/credentials/key.go
+++ b/pkg/secrethub/credentials/key.go
@@ -85,6 +85,9 @@ func ImportKey(credentialReader, passphraseReader Reader) (Key, error) {
 		if envPassphrase != "" {
 			credential, err := decryptKey([]byte(envPassphrase), encoded)
 			if err != nil {
+				if crypto.IsWrongKey(err) {
+					err = ErrCannotDecryptCredential
+				}
 				return Key{}, fmt.Errorf("decrypting credential with passphrase read from $%s: %v", credentialPassphraseEnvVar, err)
 			}
 			return Key{key: credential}, nil


### PR DESCRIPTION
There were two cases where either no error or an useless error were returned in the process of loading a credential:

- If no passphrase was provided when using the SDK, this error would get ignored altogether. This is fixed by 8a82982.
- After this was fixed, not setting a passphrase would lead to an "invalid passphrase" error instead of a "no passphrase provided error. This is fixed by 1a490aa (`passphraseReader` is now `nil` again in all cases that no passphrase is provided)
- If an invalid passphrase was provided through the environment, a crypto error would be returned. This is fixed by 9f74af2.