### PR TITLE
Improve performance of creating access rules

### DIFF
--- a/pkg/secrethub/acl.go
+++ b/pkg/secrethub/acl.go
@@ -3,6 +3,7 @@ package secrethub
 import (
 	"context"
 	"fmt"
+
 	"golang.org/x/sync/errgroup"
 
 	"github.com/secrethub/secrethub-go/internals/crypto"

--- a/pkg/secrethub/acl.go
+++ b/pkg/secrethub/acl.go
@@ -3,6 +3,8 @@ package secrethub
 import (
 	"fmt"
 
+	"github.com/secrethub/secrethub-go/internals/crypto"
+
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/api/uuid"
 	"github.com/secrethub/secrethub-go/internals/errio"
@@ -287,6 +289,10 @@ func (re *reencrypter) Add(blindName string) error {
 		return err
 	}
 
+	return re.reencrypt(encryptedTree, accountKey)
+}
+
+func (re *reencrypter) reencrypt(encryptedTree *api.EncryptedTree, accountKey *crypto.RSAPrivateKey) error {
 	for _, dir := range encryptedTree.Directories {
 		_, ok := re.dirs[dir.DirID]
 		if !ok {

--- a/pkg/secrethub/acl_test.go
+++ b/pkg/secrethub/acl_test.go
@@ -1,7 +1,6 @@
 package secrethub
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -25,9 +24,7 @@ func TestReencypter_reencrypt(t *testing.T) {
 
 	forPublicKey := forPrivateKey.Public()
 	forEncodedPublicKey, err := forPublicKey.Encode()
-	if err != nil {
-		fmt.Print(err.Error())
-	}
+	assert.OK(t, err)
 
 	firstAccount := api.Account{
 		AccountID:   uuid.New(),
@@ -105,9 +102,7 @@ func TestReencypter_reencrypt(t *testing.T) {
 
 			encryptedTree := createEncryptedTree(t, tc.dirs, tc.secrets, fakeReencrypter, firstAccount)
 			err = fakeReencrypter.reencrypt(&encryptedTree, &fromPrivateKey)
-			if err != nil {
-				fmt.Print(err.Error())
-			}
+			assert.OK(t, err)
 
 			count := 0
 			for _, dir := range fakeReencrypter.dirs {

--- a/pkg/secrethub/acl_test.go
+++ b/pkg/secrethub/acl_test.go
@@ -1,0 +1,174 @@
+package secrethub
+
+import (
+	"fmt"
+	"github.com/secrethub/secrethub-go/internals/api"
+	"github.com/secrethub/secrethub-go/internals/api/uuid"
+	"github.com/secrethub/secrethub-go/internals/assert"
+	"github.com/secrethub/secrethub-go/internals/crypto"
+	"github.com/secrethub/secrethub-go/pkg/secrethub/internals/http"
+	"testing"
+	"time"
+)
+
+type testCase struct {
+	dirs    []*api.Dir
+	secrets []*api.Secret
+	err     error
+}
+
+func TestReencypter_reencrypt(t *testing.T) {
+	fromPrivateKey, err := crypto.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		fmt.Printf(err.Error())
+	}
+
+	fromPublicKey := fromPrivateKey.Public()
+	fromEncodedPublicKey, err := fromPublicKey.Encode()
+
+	if err != nil {
+		fmt.Printf(err.Error())
+	}
+
+	forPrivateKey, err := crypto.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		fmt.Printf(err.Error())
+	}
+	forPublicKey := forPrivateKey.Public()
+	forEncodedPublicKey, err := forPublicKey.Encode()
+
+	if err != nil {
+		fmt.Printf(err.Error())
+	}
+
+	firstAccount := api.Account{
+		AccountID:   uuid.New(),
+		Name:        "first-user",
+		PublicKey:   fromEncodedPublicKey,
+		AccountType: "",
+		CreatedAt:   time.Time{},
+	}
+
+	secondAccount := api.Account{
+		AccountID:   uuid.New(),
+		Name:        "second-user",
+		PublicKey:   forEncodedPublicKey,
+		AccountType: "",
+		CreatedAt:   time.Time{},
+	}
+
+	fakeClient := Client{
+		httpClient: &http.Client{},
+		account:    &secondAccount,
+		accountKey: &forPrivateKey,
+	}
+
+	cases := map[string]testCase {
+		"no directories": {
+			dirs:    nil,
+			secrets: nil,
+		},
+		"one directory": {
+			dirs: []*api.Dir{
+				{
+					DirID: uuid.New(),
+					Name:  "first-dir",
+				},
+			},
+			secrets: nil,
+		},
+		"multiple directories": {
+			dirs: []*api.Dir{
+				{
+					DirID: uuid.New(),
+					Name:  "first-dir",
+				},
+				{
+					DirID: uuid.New(),
+					Name:  "second-dir",
+				},
+				{
+					DirID: uuid.New(),
+					Name:  "third-dir",
+				},
+				{
+					DirID: uuid.New(),
+					Name:  "fourth-dir",
+				},
+				{
+					DirID: uuid.New(),
+					Name:  "fifth-dir",
+				},
+			},
+			secrets: nil,
+		},
+	}
+	for _, caseIter := range cases {
+		fakeReencrypter := reencrypter {
+			dirs:       make(map[uuid.UUID]api.EncryptedNameForNodeRequest),
+			secrets:    make(map[uuid.UUID]api.SecretAccessRequest),
+			encryptFor: &secondAccount,
+			client:     &fakeClient,
+		}
+
+		encryptedTree := createEncryptedTree(caseIter.dirs, caseIter.secrets, fakeReencrypter, firstAccount)
+		err = fakeReencrypter.reencrypt(&encryptedTree, &fromPrivateKey)
+		if err != nil {
+			fmt.Printf(err.Error())
+		}
+
+		count := 0
+		for _, dirTemp := range fakeReencrypter.dirs {
+			assert.Equal(t, dirTemp.AccountID, secondAccount.AccountID)
+			decryptedDir, err := encryptedTree.Directories[caseIter.dirs[count].DirID].Decrypt(&fromPrivateKey)
+			if err != nil {
+				fmt.Printf(err.Error())
+			}
+			assert.Equal(t, caseIter.dirs[count].Name, decryptedDir.Name)
+			count += 1
+		}
+
+		//TODO: In order to test for secrets encryption and decryption, a refactoring of the Client is in order, as to be able to mock the HTTP Go client.
+		count = 0
+		for _, secretTemp := range fakeReencrypter.secrets {
+			assert.Equal(t, secretTemp.Name.AccountID, secondAccount.AccountID)
+			decryptedSecret, err := encryptedTree.Secrets[count].Decrypt(&fromPrivateKey)
+			if err != nil {
+				fmt.Printf(err.Error())
+			}
+			assert.Equal(t, caseIter.secrets[count].Name, decryptedSecret.Name)
+			count += 1
+
+		}
+	}
+}
+
+func createEncryptedTree(dirs []*api.Dir, secrets []*api.Secret, reencrypter reencrypter, account api.Account) api.EncryptedTree {
+	encryptedTree := api.EncryptedTree{
+		Directories: make(map[uuid.UUID]*api.EncryptedDir),
+		Secrets:     make([]*api.EncryptedSecret, len(secrets)),
+	}
+	for _, dir := range dirs {
+		request, err := reencrypter.client.encryptDirFor(dir, &account)
+		if err != nil {
+			fmt.Printf(err.Error())
+		}
+		encryptedTree.Directories[dir.DirID] = &api.EncryptedDir{
+			DirID:         dir.DirID,
+			EncryptedName: request.EncryptedName,
+		}
+	}
+
+	for i, secret := range secrets {
+		request, err := reencrypter.client.encryptSecretFor(secret, &account)
+		if err != nil {
+			fmt.Printf(err.Error())
+		}
+		encryptedTree.Secrets[i] = &api.EncryptedSecret{
+			DirID:         secret.DirID,
+			EncryptedName: request.Name.EncryptedName,
+		}
+	}
+
+	return encryptedTree
+}

--- a/pkg/secrethub/acl_test.go
+++ b/pkg/secrethub/acl_test.go
@@ -25,7 +25,6 @@ func TestReencypter_reencrypt(t *testing.T) {
 
 	fromPublicKey := fromPrivateKey.Public()
 	fromEncodedPublicKey, err := fromPublicKey.Encode()
-
 	if err != nil {
 		fmt.Print(err.Error())
 	}
@@ -34,9 +33,9 @@ func TestReencypter_reencrypt(t *testing.T) {
 	if err != nil {
 		fmt.Print(err.Error())
 	}
+
 	forPublicKey := forPrivateKey.Public()
 	forEncodedPublicKey, err := forPublicKey.Encode()
-
 	if err != nil {
 		fmt.Print(err.Error())
 	}
@@ -138,7 +137,6 @@ func TestReencypter_reencrypt(t *testing.T) {
 			}
 			assert.Equal(t, caseIter.secrets[count].Name, decryptedSecret.Name)
 			count++
-
 		}
 	}
 }

--- a/pkg/secrethub/acl_test.go
+++ b/pkg/secrethub/acl_test.go
@@ -14,20 +14,14 @@ import (
 
 func TestReencypter_reencrypt(t *testing.T) {
 	fromPrivateKey, err := crypto.GenerateRSAPrivateKey(2048)
-	if err != nil {
-		fmt.Print(err.Error())
-	}
+	assert.OK(t, err)
 
 	fromPublicKey := fromPrivateKey.Public()
 	fromEncodedPublicKey, err := fromPublicKey.Encode()
-	if err != nil {
-		fmt.Print(err.Error())
-	}
+	assert.OK(t, err)
 
 	forPrivateKey, err := crypto.GenerateRSAPrivateKey(2048)
-	if err != nil {
-		fmt.Print(err.Error())
-	}
+	assert.OK(t, err)
 
 	forPublicKey := forPrivateKey.Public()
 	forEncodedPublicKey, err := forPublicKey.Encode()
@@ -108,7 +102,7 @@ func TestReencypter_reencrypt(t *testing.T) {
 			client:     &fakeClient,
 		}
 
-		encryptedTree := createEncryptedTree(tc.dirs, tc.secrets, fakeReencrypter, firstAccount)
+		encryptedTree := createEncryptedTree(t, tc.dirs, tc.secrets, fakeReencrypter, firstAccount)
 		err = fakeReencrypter.reencrypt(&encryptedTree, &fromPrivateKey)
 		if err != nil {
 			fmt.Print(err.Error())
@@ -118,9 +112,7 @@ func TestReencypter_reencrypt(t *testing.T) {
 		for _, dirTemp := range fakeReencrypter.dirs {
 			assert.Equal(t, dirTemp.AccountID, secondAccount.AccountID)
 			decryptedDir, err := encryptedTree.Directories[tc.dirs[count].DirID].Decrypt(&fromPrivateKey)
-			if err != nil {
-				fmt.Print(err.Error())
-			}
+			assert.OK(t, err)
 			assert.Equal(t, tc.dirs[count].Name, decryptedDir.Name)
 			count++
 		}
@@ -130,25 +122,21 @@ func TestReencypter_reencrypt(t *testing.T) {
 		for _, secretTemp := range fakeReencrypter.secrets {
 			assert.Equal(t, secretTemp.Name.AccountID, secondAccount.AccountID)
 			decryptedSecret, err := encryptedTree.Secrets[count].Decrypt(&fromPrivateKey)
-			if err != nil {
-				fmt.Print(err.Error())
-			}
+			assert.OK(t, err)
 			assert.Equal(t, tc.secrets[count].Name, decryptedSecret.Name)
 			count++
 		}
 	}
 }
 
-func createEncryptedTree(dirs []*api.Dir, secrets []*api.Secret, reencrypter reencrypter, account api.Account) api.EncryptedTree {
+func createEncryptedTree(t *testing.T, dirs []*api.Dir, secrets []*api.Secret, reencrypter reencrypter, account api.Account) api.EncryptedTree {
 	encryptedTree := api.EncryptedTree{
 		Directories: make(map[uuid.UUID]*api.EncryptedDir),
 		Secrets:     make([]*api.EncryptedSecret, len(secrets)),
 	}
 	for _, dir := range dirs {
 		request, err := reencrypter.client.encryptDirFor(dir, &account)
-		if err != nil {
-			fmt.Print(err.Error())
-		}
+		assert.OK(t, err)
 		encryptedTree.Directories[dir.DirID] = &api.EncryptedDir{
 			DirID:         dir.DirID,
 			EncryptedName: request.EncryptedName,
@@ -157,9 +145,7 @@ func createEncryptedTree(dirs []*api.Dir, secrets []*api.Secret, reencrypter ree
 
 	for i, secret := range secrets {
 		request, err := reencrypter.client.encryptSecretFor(secret, &account)
-		if err != nil {
-			fmt.Print(err.Error())
-		}
+		assert.OK(t, err)
 		encryptedTree.Secrets[i] = &api.EncryptedSecret{
 			DirID:         secret.DirID,
 			EncryptedName: request.Name.EncryptedName,

--- a/pkg/secrethub/acl_test.go
+++ b/pkg/secrethub/acl_test.go
@@ -2,43 +2,43 @@ package secrethub
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/api/uuid"
 	"github.com/secrethub/secrethub-go/internals/assert"
 	"github.com/secrethub/secrethub-go/internals/crypto"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/internals/http"
-	"testing"
-	"time"
 )
 
 type testCase struct {
 	dirs    []*api.Dir
 	secrets []*api.Secret
-	err     error
 }
 
 func TestReencypter_reencrypt(t *testing.T) {
 	fromPrivateKey, err := crypto.GenerateRSAPrivateKey(2048)
 	if err != nil {
-		fmt.Printf(err.Error())
+		fmt.Print(err.Error())
 	}
 
 	fromPublicKey := fromPrivateKey.Public()
 	fromEncodedPublicKey, err := fromPublicKey.Encode()
 
 	if err != nil {
-		fmt.Printf(err.Error())
+		fmt.Print(err.Error())
 	}
 
 	forPrivateKey, err := crypto.GenerateRSAPrivateKey(2048)
 	if err != nil {
-		fmt.Printf(err.Error())
+		fmt.Print(err.Error())
 	}
 	forPublicKey := forPrivateKey.Public()
 	forEncodedPublicKey, err := forPublicKey.Encode()
 
 	if err != nil {
-		fmt.Printf(err.Error())
+		fmt.Print(err.Error())
 	}
 
 	firstAccount := api.Account{
@@ -63,7 +63,7 @@ func TestReencypter_reencrypt(t *testing.T) {
 		accountKey: &forPrivateKey,
 	}
 
-	cases := map[string]testCase {
+	cases := map[string]testCase{
 		"no directories": {
 			dirs:    nil,
 			secrets: nil,
@@ -104,7 +104,7 @@ func TestReencypter_reencrypt(t *testing.T) {
 		},
 	}
 	for _, caseIter := range cases {
-		fakeReencrypter := reencrypter {
+		fakeReencrypter := reencrypter{
 			dirs:       make(map[uuid.UUID]api.EncryptedNameForNodeRequest),
 			secrets:    make(map[uuid.UUID]api.SecretAccessRequest),
 			encryptFor: &secondAccount,
@@ -114,7 +114,7 @@ func TestReencypter_reencrypt(t *testing.T) {
 		encryptedTree := createEncryptedTree(caseIter.dirs, caseIter.secrets, fakeReencrypter, firstAccount)
 		err = fakeReencrypter.reencrypt(&encryptedTree, &fromPrivateKey)
 		if err != nil {
-			fmt.Printf(err.Error())
+			fmt.Print(err.Error())
 		}
 
 		count := 0
@@ -122,10 +122,10 @@ func TestReencypter_reencrypt(t *testing.T) {
 			assert.Equal(t, dirTemp.AccountID, secondAccount.AccountID)
 			decryptedDir, err := encryptedTree.Directories[caseIter.dirs[count].DirID].Decrypt(&fromPrivateKey)
 			if err != nil {
-				fmt.Printf(err.Error())
+				fmt.Print(err.Error())
 			}
 			assert.Equal(t, caseIter.dirs[count].Name, decryptedDir.Name)
-			count += 1
+			count++
 		}
 
 		//TODO: In order to test for secrets encryption and decryption, a refactoring of the Client is in order, as to be able to mock the HTTP Go client.
@@ -134,10 +134,10 @@ func TestReencypter_reencrypt(t *testing.T) {
 			assert.Equal(t, secretTemp.Name.AccountID, secondAccount.AccountID)
 			decryptedSecret, err := encryptedTree.Secrets[count].Decrypt(&fromPrivateKey)
 			if err != nil {
-				fmt.Printf(err.Error())
+				fmt.Print(err.Error())
 			}
 			assert.Equal(t, caseIter.secrets[count].Name, decryptedSecret.Name)
-			count += 1
+			count++
 
 		}
 	}
@@ -151,7 +151,7 @@ func createEncryptedTree(dirs []*api.Dir, secrets []*api.Secret, reencrypter ree
 	for _, dir := range dirs {
 		request, err := reencrypter.client.encryptDirFor(dir, &account)
 		if err != nil {
-			fmt.Printf(err.Error())
+			fmt.Print(err.Error())
 		}
 		encryptedTree.Directories[dir.DirID] = &api.EncryptedDir{
 			DirID:         dir.DirID,
@@ -162,7 +162,7 @@ func createEncryptedTree(dirs []*api.Dir, secrets []*api.Secret, reencrypter ree
 	for i, secret := range secrets {
 		request, err := reencrypter.client.encryptSecretFor(secret, &account)
 		if err != nil {
-			fmt.Printf(err.Error())
+			fmt.Print(err.Error())
 		}
 		encryptedTree.Secrets[i] = &api.EncryptedSecret{
 			DirID:         secret.DirID,

--- a/pkg/secrethub/acl_test.go
+++ b/pkg/secrethub/acl_test.go
@@ -110,8 +110,8 @@ func TestReencypter_reencrypt(t *testing.T) {
 			}
 
 			count := 0
-			for _, dirTemp := range fakeReencrypter.dirs {
-				assert.Equal(t, dirTemp.AccountID, secondAccount.AccountID)
+			for _, dir := range fakeReencrypter.dirs {
+				assert.Equal(t, dir.AccountID, secondAccount.AccountID)
 				decryptedDir, err := encryptedTree.Directories[tc.dirs[count].DirID].Decrypt(&fromPrivateKey)
 				assert.OK(t, err)
 				assert.Equal(t, tc.dirs[count].Name, decryptedDir.Name)
@@ -120,8 +120,8 @@ func TestReencypter_reencrypt(t *testing.T) {
 
 			//TODO: In order to test for secrets encryption and decryption, a refactoring of the Client is in order, as to be able to mock the HTTP Go client.
 			count = 0
-			for _, secretTemp := range fakeReencrypter.secrets {
-				assert.Equal(t, secretTemp.Name.AccountID, secondAccount.AccountID)
+			for _, secret := range fakeReencrypter.secrets {
+				assert.Equal(t, secret.Name.AccountID, secondAccount.AccountID)
 				decryptedSecret, err := encryptedTree.Secrets[count].Decrypt(&fromPrivateKey)
 				assert.OK(t, err)
 				assert.Equal(t, tc.secrets[count].Name, decryptedSecret.Name)


### PR DESCRIPTION
In order to check if the optimisation is effectual, I have run the following script, which populated the priorly created `optimization-test` directory with 1000 secrets:

```go
u, err := secrethub.NewClient()
if err != nil {
	fmt.Print(err.Error())
}

iterations := 1000
for i := 0; i < iterations; i++ {
	_, err := u.Secrets().Write(fmt.Sprintf("<SECRETHUB NAMESPACE>/optimization/optimization-test/secret%d", i), []byte(fmt.Sprintf("value%d", i)))
	if err != nil {
		fmt.Print(err.Error())
	}
}
```

I have then replaced the CLI's SDK dependency by pasting the following in CLI project's `go.mod`:
```
replace (
    github.com/secrethub/secrethub-go => <RELATIVE PATH TO secrethub-go FOLDER>  // in my case, ../secrethub-go
)
```
and then I rebuilt the CLI.

NB, I was on the `feature/refactor-and-test-acl` branch on the SDK.

The effect of the pull request can be observed by comparing the running times of an `acl set` command run on a directory with a large number of secrets (such as the one created by the script above), before and after the change, which, in my experience, differed by quite a large factor. 

If anyone considers this necessary, I will measure the actual times for both the before and after cases, making use of the `duration` library.