### PR TITLE
Account delete

### DIFF
--- a/pkg/secrethub/account.go
+++ b/pkg/secrethub/account.go
@@ -2,6 +2,7 @@ package secrethub
 
 import (
 	"github.com/secrethub/secrethub-go/internals/api"
+	"github.com/secrethub/secrethub-go/internals/api/uuid"
 	"github.com/secrethub/secrethub-go/internals/crypto"
 	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
@@ -10,12 +11,16 @@ import (
 // Errors
 var (
 	ErrNoDecryptionKey = errClient.Code("no_decryption_key").Error("client is not initialized with a method to decrypt the account key")
+	ErrIncorrectAccountID = errClient.Code("incorrect_account_id").Error("the incorrect account ID was provided. To delete the currently authenticated account please provide its ID.")
 )
 
 // AccountService handles operations on SecretHub accounts.
 type AccountService interface {
 	// Me retrieves the authenticated account of the client.
 	Me() (*api.Account, error)
+	// Delete deletes the authenticated account of the client if it's ID is provided as a parameter.
+	// Do not use this method. Account deletes should only be performed from the CLI.
+	Delete(accountID uuid.UUID) error
 	// Get retrieves an account by name.
 	Get(name string) (*api.Account, error)
 	// Keys returns an account key service.
@@ -35,6 +40,19 @@ type accountService struct {
 // Me retrieves the authenticated account of the client.
 func (s accountService) Me() (*api.Account, error) {
 	return s.client.getMyAccount()
+}
+
+// Delete deletes the authenticated account of the client if it's ID is provided as a parameter.
+// Do not use this method. Account deletes should only be performed from the CLI.
+func (s accountService) Delete(accountID uuid.UUID) error {
+	account, err := s.client.getMyAccount()
+	if err != nil {
+		return err
+	}
+	if accountID != account.AccountID {
+		return ErrIncorrectAccountID
+	}
+	return s.client.httpClient.DeleteMyAccount()
 }
 
 // Get retrieves an account by name.

--- a/pkg/secrethub/account.go
+++ b/pkg/secrethub/account.go
@@ -10,7 +10,7 @@ import (
 
 // Errors
 var (
-	ErrNoDecryptionKey = errClient.Code("no_decryption_key").Error("client is not initialized with a method to decrypt the account key")
+	ErrNoDecryptionKey    = errClient.Code("no_decryption_key").Error("client is not initialized with a method to decrypt the account key")
 	ErrIncorrectAccountID = errClient.Code("incorrect_account_id").Error("the incorrect account ID was provided. To delete the currently authenticated account please provide its ID.")
 )
 

--- a/pkg/secrethub/fakeclient/account.go
+++ b/pkg/secrethub/fakeclient/account.go
@@ -4,12 +4,14 @@ package fakeclient
 
 import (
 	"github.com/secrethub/secrethub-go/internals/api"
+	"github.com/secrethub/secrethub-go/internals/api/uuid"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 )
 
 // AccountService is a mock of the AccountService interface.
 type AccountService struct {
 	MeFunc            func() (*api.Account, error)
+	DeleteFunc        func(accountID uuid.UUID) error
 	GetFunc           func(name string) (*api.Account, error)
 	AccountKeyService secrethub.AccountKeyService
 }
@@ -21,6 +23,11 @@ func (s *AccountService) Keys() secrethub.AccountKeyService {
 // Get implements the AccountService interface Get function.
 func (s *AccountService) Get(name string) (*api.Account, error) {
 	return s.GetFunc(name)
+}
+
+// Delete implements the AccountService interface Delete function.
+func (s *AccountService) Delete(accountID uuid.UUID) error {
+	return s.DeleteFunc(accountID)
 }
 
 // Me implements the AccountService interface Me function.

--- a/pkg/secrethub/internals/http/client.go
+++ b/pkg/secrethub/internals/http/client.go
@@ -37,6 +37,7 @@ const (
 
 	// Current account
 	pathMeUser              = "%s/me/user"
+	pathMeAccount           = "%s/me/account"
 	pathMeRepos             = "%s/me/repos"
 	pathMeKey               = "%s/me/key?key_version=v2"
 	pathMeEmailVerification = "%s/me/user/verification-email"
@@ -171,6 +172,13 @@ func (c *Client) GetMyUser() (*api.User, error) {
 	rawURL := fmt.Sprintf(pathMeUser, c.base.String())
 	err := c.get(rawURL, true, out)
 	return out, errio.Error(err)
+}
+
+// DeleteMyAccount
+func (c *Client) DeleteMyAccount() error {
+	rawURL := fmt.Sprintf(pathMeAccount, c.base.String())
+	err := c.delete(rawURL, true, nil)
+	return errio.Error(err)
 }
 
 // CreateCredential creates a new credential for the account.


### PR DESCRIPTION
This PR adds a `Delete` method to the account service, that deletes the currently authenticated account.

To prevent users from calling this method accidentally, the method requires you to pass your own account id as parameter.